### PR TITLE
TRIVIAL: fix GitHub Actions on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
 
   test:
     name: Node.js ${{ matrix.node_version }} on ${{ matrix.os }}
+    if: always()
     needs:
       - cancel
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Before to this change, tests were not run in the master branch due to skipped `cancel` job.