### PR TITLE
Completely remove the old mode from the 'fs.scandir' package

### DIFF
--- a/packages/fs/fs.scandir/src/adapters/fs.ts
+++ b/packages/fs/fs.scandir/src/adapters/fs.ts
@@ -4,11 +4,7 @@ import type * as fsStat from '@nodelib/fs.stat';
 
 import type { Dirent, ErrnoException } from '../types';
 
-export interface ReaddirAsynchronousMethod {
-	(filepath: string, options: { withFileTypes: true }, callback: (error: ErrnoException | null, files: Dirent[]) => void): void;
-	(filepath: string, callback: (error: ErrnoException | null, files: string[]) => void): void;
-}
-
+export type ReaddirAsynchronousMethod = (filepath: string, options: { withFileTypes: true }, callback: (error: ErrnoException | null, files: Dirent[]) => void) => void;
 export type ReaddirSynchronousMethod = (filepath: string, options: { withFileTypes: true }) => Dirent[];
 
 export type FileSystemAdapter = fsStat.FileSystemAdapter & {

--- a/packages/fs/fs.scandir/src/adapters/fs.ts
+++ b/packages/fs/fs.scandir/src/adapters/fs.ts
@@ -9,10 +9,7 @@ export interface ReaddirAsynchronousMethod {
 	(filepath: string, callback: (error: ErrnoException | null, files: string[]) => void): void;
 }
 
-export interface ReaddirSynchronousMethod {
-	(filepath: string, options: { withFileTypes: true }): Dirent[];
-	(filepath: string): string[];
-}
+export type ReaddirSynchronousMethod = (filepath: string, options: { withFileTypes: true }) => Dirent[];
 
 export type FileSystemAdapter = fsStat.FileSystemAdapter & {
 	readdir: ReaddirAsynchronousMethod;

--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -1,210 +1,170 @@
 import * as assert from 'assert';
 import * as path from 'path';
+import * as util from 'util';
 
 import * as sinon from 'sinon';
 
 import { Dirent, Stats } from '@nodelib/fs.macchiato';
 import Settings from '../settings';
 import type { Entry } from '../types';
+import * as utils from '../utils';
 import * as provider from './async';
 
-const ROOT_PATH = 'root';
-const FIRST_FILE_PATH = 'first.txt';
-const SECOND_FILE_PATH = 'second.txt';
-const FIRST_ENTRY_PATH = path.join(ROOT_PATH, FIRST_FILE_PATH);
-const SECOND_ENTRY_PATH = path.join(ROOT_PATH, SECOND_FILE_PATH);
+const read = util.promisify(provider.read);
 
 describe('Providers → Async', () => {
 	describe('.read', () => {
-		it('should always use `readdir` method when the `stats` option is enabled', (done) => {
-			const readdir = sinon.stub();
+		it('should return entries', async () => {
+			const dirent = new Dirent({ name: 'file.txt' });
 
-			readdir.yields(null, []);
+			const readdir = sinon.stub().yields(null, [dirent]);
 
 			const settings = new Settings({
 				fs: { readdir },
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
+
+			const actual = await read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should return entries with the "stats" property', async () => {
+			const dirent = new Dirent({ name: 'file.txt' });
+			const stats = new Stats();
+
+			const readdir = sinon.stub().yields(null, [dirent]);
+			const lstat = sinon.stub().yields(null, stats);
+
+			const settings = new Settings({
+				fs: { readdir, lstat },
 				stats: true,
 			});
 
-			provider.read(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+				stats,
+			}];
 
-				assert.deepStrictEqual(entries, []);
-				sinon.assert.match(readdir.args, [[ROOT_PATH, sinon.match.func]]);
+			const actual = await read('root', settings);
 
-				done();
-			});
+			assert.deepStrictEqual(actual, expected);
 		});
-	});
 
-	describe('.readdirWithFileTypes', () => {
-		it('should return entries', (done) => {
-			const dirent = new Dirent({ name: FIRST_FILE_PATH });
-			const readdir = sinon.stub();
+		it('should update Dirent when the "stats" and "followSymbolicLinks" options are enabled', async () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const stats = new Stats();
 
-			readdir.yields(null, [dirent]);
+			const readdir = sinon.stub().yields(null, [dirent]);
+			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const stat = sinon.stub().yields(null, stats);
+
+			const settings = new Settings({
+				fs: { readdir, lstat, stat },
+				stats: true,
+				followSymbolicLinks: true,
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent: utils.fs.createDirentFromStats('file.txt', stats),
+				stats,
+			}];
+
+			const actual = await read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should update Dirent when the "followSymbolicLinks" option is enabled', async () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const stats = new Stats();
+
+			const readdir = sinon.stub().yields(null, [dirent]);
+			const stat = sinon.stub().yields(null, stats);
+
+			const settings = new Settings({
+				fs: { readdir, stat },
+				followSymbolicLinks: true,
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent: utils.fs.createDirentFromStats('file.txt', stats),
+			}];
+
+			const actual = await read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should do nothing with symbolic links when the "followSymbolicLinks" option is disabled', async () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+
+			const readdir = sinon.stub().yields(null, [dirent]);
 
 			const settings = new Settings({
 				fs: { readdir },
 			});
 
-			const expected: Entry[] = [
-				{
-					dirent,
-					name: FIRST_FILE_PATH,
-					path: FIRST_ENTRY_PATH,
-				},
-			];
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
 
-			provider.readdirWithFileTypes(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
+			const actual = await read('root', settings);
 
-				sinon.assert.match(readdir.args, [[ROOT_PATH, { withFileTypes: true }, sinon.match.func]]);
-				assert.deepStrictEqual(entries, expected);
-
-				done();
-			});
+			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should call fs.stat for symbolic link when the "followSymbolicLink" option is enabled', (done) => {
-			const firstDirent = new Dirent({ name: FIRST_FILE_PATH });
-			const secondDirent = new Dirent({ name: SECOND_FILE_PATH, isSymbolicLink: true });
-			const stats = new Stats();
+		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', async () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
 
-			const readdir = sinon.stub();
-			const stat = sinon.stub();
-
-			readdir.yields(null, [firstDirent, secondDirent]);
-			stat.yields(null, stats);
-
-			const settings = new Settings({
-				followSymbolicLinks: true,
-				fs: {
-					readdir,
-					stat,
-				},
-			});
-
-			provider.readdirWithFileTypes(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
-
-				assert.strictEqual(entries.length, 2);
-				assert.strictEqual(entries[1]?.dirent.isSymbolicLink(), false);
-				sinon.assert.match(stat.args, [[SECOND_ENTRY_PATH, sinon.match.func]]);
-
-				done();
-			});
-		});
-
-		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', (done) => {
-			const firstDirent = new Dirent({ name: FIRST_FILE_PATH, isSymbolicLink: true });
-
-			const readdir = sinon.stub();
-			const stat = sinon.stub();
-
-			readdir.yields(null, [firstDirent]);
-			stat.yields(new Error('error'));
+			const readdir = sinon.stub().yields(null, [dirent]);
+			const stat = sinon.stub().yields(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,
 				throwErrorOnBrokenSymbolicLink: false,
-				fs: {
-					readdir,
-					stat,
-				},
+				fs: { readdir, stat },
 			});
 
-			provider.readdirWithFileTypes(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
 
-				assert.strictEqual(entries.length, 1);
-				assert.ok(entries[0]?.dirent.isSymbolicLink());
+			const actual = await read('root', settings);
 
-				done();
-			});
+			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should throw an error fro broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', (done) => {
-			const firstDirent = new Dirent({ name: FIRST_FILE_PATH, isSymbolicLink: true });
+		it('should throw an error for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', async () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
 
-			const readdir = sinon.stub();
-			const stat = sinon.stub();
-
-			readdir.yields(null, [firstDirent]);
-			stat.yields(new Error('error'));
+			const readdir = sinon.stub().yields(null, [dirent]);
+			const stat = sinon.stub().yields(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,
 				throwErrorOnBrokenSymbolicLink: true,
-				fs: {
-					readdir,
-					stat,
-				},
+				fs: { readdir, stat },
 			});
 
-			provider.readdirWithFileTypes(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error.message, 'error');
-				assert.strictEqual(entries, undefined);
+			const expectedErrorMessageRe = /Error: error/;
 
-				done();
-			});
-		});
-	});
-
-	describe('.readdir', () => {
-		it('should return entries', (done) => {
-			const stats = new Stats();
-
-			const readdir = sinon.stub();
-			const lstat = sinon.stub();
-
-			readdir.yields(null, [FIRST_FILE_PATH]);
-			lstat.yields(null, stats);
-
-			const settings = new Settings({
-				fs: {
-					readdir,
-					lstat,
-				},
-			});
-
-			provider.readdir(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
-
-				sinon.assert.match(readdir.args, [[ROOT_PATH, sinon.match.func]]);
-				sinon.assert.match(lstat.args, [[FIRST_ENTRY_PATH, sinon.match.func]]);
-
-				assert.strictEqual(entries[0]?.name, FIRST_FILE_PATH);
-				assert.strictEqual(entries[0]?.path, FIRST_ENTRY_PATH);
-				assert.strictEqual(entries[0]?.dirent.name, FIRST_FILE_PATH);
-
-				done();
-			});
-		});
-
-		it('should return entries with `stats` property', (done) => {
-			const stats = new Stats();
-
-			const readdir = sinon.stub();
-			const lstat = sinon.stub();
-
-			readdir.yields(null, [FIRST_FILE_PATH]);
-			lstat.yields(null, stats);
-
-			const settings = new Settings({
-				fs: {
-					readdir,
-					lstat,
-				},
-				stats: true,
-			});
-
-			provider.readdir(ROOT_PATH, settings, (error, entries) => {
-				assert.strictEqual(error, null);
-				assert.deepStrictEqual(entries[0]?.stats, stats);
-
-				done();
-			});
+			await assert.rejects(read('root', settings), expectedErrorMessageRe);
 		});
 	});
 });

--- a/packages/fs/fs.scandir/src/providers/sync.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.spec.ts
@@ -6,80 +6,129 @@ import * as sinon from 'sinon';
 import { Dirent, Stats } from '@nodelib/fs.macchiato';
 import Settings from '../settings';
 import type { Entry } from '../types';
+import * as utils from '../utils';
 import * as provider from './sync';
-
-const ROOT_PATH = 'root';
-const FIRST_FILE_PATH = 'first.txt';
-const SECOND_FILE_PATH = 'second.txt';
-const FIRST_ENTRY_PATH = path.join(ROOT_PATH, FIRST_FILE_PATH);
-const SECOND_ENTRY_PATH = path.join(ROOT_PATH, SECOND_FILE_PATH);
 
 describe('Providers → Sync', () => {
 	describe('.read', () => {
-		it('should always use `readdir` method when the `stats` option is enabled', () => {
-			const readdirSync = sinon.stub().returns([]);
-
-			const settings = new Settings({
-				fs: { readdirSync },
-				stats: true,
-			});
-
-			provider.read(ROOT_PATH, settings);
-
-			assert.deepStrictEqual(readdirSync.args, [[ROOT_PATH]]);
-		});
-	});
-
-	describe('.readdirWithFileTypes', () => {
 		it('should return entries', () => {
-			const dirent = new Dirent({ name: FIRST_FILE_PATH });
+			const dirent = new Dirent({ name: 'file.txt' });
+
 			const readdirSync = sinon.stub().returns([dirent]);
 
 			const settings = new Settings({
 				fs: { readdirSync },
 			});
 
-			const expected: Entry[] = [
-				{
-					dirent,
-					name: FIRST_FILE_PATH,
-					path: FIRST_ENTRY_PATH,
-				},
-			];
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
 
-			const actual = provider.readdirWithFileTypes(ROOT_PATH, settings);
+			const actual = provider.read('root', settings);
 
-			assert.deepStrictEqual(readdirSync.args, [[ROOT_PATH, { withFileTypes: true }]]);
 			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should call fs.stat for symbolic link when the "followSymbolicLink" option is enabled', () => {
-			const firstDirent = new Dirent({ name: FIRST_FILE_PATH });
-			const secondDirent = new Dirent({ name: SECOND_FILE_PATH, isSymbolicLink: true });
+		it('should return entries with the "stats" property', () => {
+			const dirent = new Dirent({ name: 'file.txt' });
 			const stats = new Stats();
 
-			const readdirSync = sinon.stub().returns([firstDirent, secondDirent]);
+			const readdirSync = sinon.stub().returns([dirent]);
+			const lstatSync = sinon.stub().returns(stats);
+
+			const settings = new Settings({
+				fs: { readdirSync, lstatSync },
+				stats: true,
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+				stats,
+			}];
+
+			const actual = provider.read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should update Dirent when the "stats" and "followSymbolicLinks" options are enabled', () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const stats = new Stats();
+
+			const readdirSync = sinon.stub().returns([dirent]);
+			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
 			const statSync = sinon.stub().returns(stats);
 
 			const settings = new Settings({
+				fs: { readdirSync, lstatSync, statSync },
+				stats: true,
 				followSymbolicLinks: true,
-				fs: { readdirSync, statSync },
 			});
 
-			const actual = provider.readdirWithFileTypes(ROOT_PATH, settings);
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent: utils.fs.createDirentFromStats('file.txt', stats),
+				stats,
+			}];
 
-			assert.strictEqual(actual.length, 2);
-			assert.deepStrictEqual(statSync.args, [[SECOND_ENTRY_PATH]]);
-			assert.strictEqual(actual[1]?.dirent.isSymbolicLink(), false);
+			const actual = provider.read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should update Dirent when the "followSymbolicLinks" option is enabled', () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const stats = new Stats();
+
+			const readdirSync = sinon.stub().returns([dirent]);
+			const statSync = sinon.stub().returns(stats);
+
+			const settings = new Settings({
+				fs: { readdirSync, statSync },
+				followSymbolicLinks: true,
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent: utils.fs.createDirentFromStats('file.txt', stats),
+			}];
+
+			const actual = provider.read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
+		});
+
+		it('should do nothing with symbolic links when the "followSymbolicLinks" option is disabled', () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+
+			const readdirSync = sinon.stub().returns([dirent]);
+
+			const settings = new Settings({
+				fs: { readdirSync },
+			});
+
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
+
+			const actual = provider.read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
 		});
 
 		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', () => {
-			const dirent = new Dirent({ name: FIRST_FILE_PATH, isSymbolicLink: true });
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
 
 			const readdirSync = sinon.stub().returns([dirent]);
-			const statSync = (): never => {
-				throw new Error('error');
-			};
+			const statSync = sinon.stub().throws(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,
@@ -87,18 +136,22 @@ describe('Providers → Sync', () => {
 				fs: { readdirSync, statSync },
 			});
 
-			const actual = provider.readdirWithFileTypes(ROOT_PATH, settings);
+			const expected: Entry[] = [{
+				name: 'file.txt',
+				path: path.join('root', 'file.txt'),
+				dirent,
+			}];
 
-			assert.strictEqual(actual.length, 1);
+			const actual = provider.read('root', settings);
+
+			assert.deepStrictEqual(actual, expected);
 		});
 
-		it('should throw an error fro broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', () => {
-			const dirent = new Dirent({ name: FIRST_FILE_PATH, isSymbolicLink: true });
+		it('should throw an error for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', () => {
+			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
 
 			const readdirSync = sinon.stub().returns([dirent]);
-			const statSync = (): never => {
-				throw new Error('error');
-			};
+			const statSync = sinon.stub().throws(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,
@@ -108,44 +161,7 @@ describe('Providers → Sync', () => {
 
 			const expectedErrorMessageRe = /Error: error/;
 
-			assert.throws(() => provider.readdirWithFileTypes(ROOT_PATH, settings), expectedErrorMessageRe);
-		});
-	});
-
-	describe('.readdir', () => {
-		it('should return entries', () => {
-			const stats = new Stats();
-
-			const readdirSync = sinon.stub().returns([FIRST_FILE_PATH]);
-			const lstatSync = sinon.stub().returns(stats);
-
-			const settings = new Settings({
-				fs: { readdirSync, lstatSync },
-			});
-
-			const actual = provider.readdir(ROOT_PATH, settings);
-
-			assert.deepStrictEqual(readdirSync.args, [[ROOT_PATH]]);
-
-			assert.strictEqual(actual[0]?.name, FIRST_FILE_PATH);
-			assert.strictEqual(actual[0]?.path, FIRST_ENTRY_PATH);
-			assert.strictEqual(actual[0]?.dirent.name, FIRST_FILE_PATH);
-		});
-
-		it('should return entries with `stats` property', () => {
-			const stats = new Stats();
-
-			const readdirSync = sinon.stub().returns([FIRST_FILE_PATH]);
-			const lstatSync = sinon.stub().returns(stats);
-
-			const settings = new Settings({
-				fs: { readdirSync, lstatSync },
-				stats: true,
-			});
-
-			const actual = provider.readdir(ROOT_PATH, settings);
-
-			assert.deepStrictEqual(actual[0]?.stats, stats);
+			assert.throws(() => provider.read('root', settings), expectedErrorMessageRe);
 		});
 	});
 });

--- a/packages/fs/fs.scandir/src/providers/sync.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.ts
@@ -6,14 +6,6 @@ import * as utils from '../utils';
 import * as common from './common';
 
 export function read(directory: string, settings: Settings): Entry[] {
-	if (!settings.stats) {
-		return readdirWithFileTypes(directory, settings);
-	}
-
-	return readdir(directory, settings);
-}
-
-export function readdirWithFileTypes(directory: string, settings: Settings): Entry[] {
 	const dirents = settings.fs.readdirSync(directory, { withFileTypes: true });
 
 	return dirents.map((dirent) => {
@@ -23,9 +15,13 @@ export function readdirWithFileTypes(directory: string, settings: Settings): Ent
 			path: common.joinPathSegments(directory, dirent.name, settings.pathSegmentSeparator),
 		};
 
-		if (entry.dirent.isSymbolicLink() && settings.followSymbolicLinks) {
+		if (settings.stats) {
+			entry.stats = fsStat.statSync(entry.path, settings.fsStatSettings);
+		}
+
+		if (settings.followSymbolicLinks && entry.dirent.isSymbolicLink()) {
 			try {
-				const stats = settings.fs.statSync(entry.path);
+				const stats = entry.stats ?? settings.fs.statSync(entry.path);
 
 				entry.dirent = utils.fs.createDirentFromStats(entry.name, stats);
 			} catch (error: unknown) {
@@ -33,27 +29,6 @@ export function readdirWithFileTypes(directory: string, settings: Settings): Ent
 					throw (error as ErrnoException);
 				}
 			}
-		}
-
-		return entry;
-	});
-}
-
-export function readdir(directory: string, settings: Settings): Entry[] {
-	const names = settings.fs.readdirSync(directory);
-
-	return names.map((name) => {
-		const entryPath = common.joinPathSegments(directory, name, settings.pathSegmentSeparator);
-		const stats = fsStat.statSync(entryPath, settings.fsStatSettings);
-
-		const entry: Entry = {
-			name,
-			path: entryPath,
-			dirent: utils.fs.createDirentFromStats(name, stats),
-		};
-
-		if (settings.stats) {
-			entry.stats = stats;
 		}
 
 		return entry;

--- a/packages/fs/fs.stat/src/providers/async.spec.ts
+++ b/packages/fs/fs.stat/src/providers/async.spec.ts
@@ -93,7 +93,7 @@ describe('Providers → Async', () => {
 			});
 
 			provider.read('filepath', settings, (error) => {
-				assert.strictEqual(error.message, 'broken');
+				assert.strictEqual(error?.message, 'broken');
 				done();
 			});
 		});

--- a/packages/fs/fs.stat/src/providers/async.ts
+++ b/packages/fs/fs.stat/src/providers/async.ts
@@ -1,10 +1,9 @@
 import type Settings from '../settings';
 import type { ErrnoException, Stats } from '../types';
 
-type FailureCallback = (error: ErrnoException) => void;
-type SuccessCallback = (error: null, stats: Stats) => void;
+type FailureCallback = (error: ErrnoException | null) => void;
 
-export type AsyncCallback = (error: ErrnoException, stats: Stats) => void;
+export type AsyncCallback = (error: ErrnoException | null, stats: Stats) => void;
 
 export function read(path: string, settings: Settings, callback: AsyncCallback): void {
 	settings.fs.lstat(path, (lstatError, lstat) => {
@@ -38,10 +37,10 @@ export function read(path: string, settings: Settings, callback: AsyncCallback):
 	});
 }
 
-function callFailureCallback(callback: AsyncCallback, error: ErrnoException): void {
+function callFailureCallback(callback: AsyncCallback, error: ErrnoException | null): void {
 	(callback as FailureCallback)(error);
 }
 
 function callSuccessCallback(callback: AsyncCallback, result: Stats): void {
-	(callback as unknown as SuccessCallback)(null, result);
+	callback(null, result);
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Remove the old mode from the 'fs.scandir' package.

#### What changes did you make? (Give an overview)

1. The basic functions of providers have been simplified.
1. Additional tests have been written for providers.
1. The `utils.fs.createDirentFromStats` function has been rewritten based on a similar one in Node.js.