### PR TITLE
Implement fs.Dirent and fs.Stats more correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
   "devDependencies": {
     "@nodelib-internal/tools.size-limit": "file:tools/size-limit",
     "@times-components/depend": "2.1.15",
-    "@types/mocha": "^9.0.0",
-    "@types/node": "^12.20.37",
+    "@types/mocha": "^9.1.1",
+    "@types/node": "^12.20.52",
     "@types/rimraf": "^3.0.2",
-    "@types/sinon": "^10.0.6",
-    "eslint": "^8.6.0",
+    "@types/sinon": "^10.0.11",
+    "eslint": "^8.16.0",
     "eslint-config-mrmlnc": "^2.1.0",
-    "lerna": "^4.0.0",
-    "mocha": "^9.1.3",
+    "lerna": "^5.0.0",
+    "mocha": "^10.0.0",
     "rimraf": "^3.0.2",
-    "sinon": "^12.0.1",
-    "typescript": "^4.5.4"
+    "sinon": "^14.0.0",
+    "typescript": "^4.7.2"
   }
 }

--- a/packages/fs/fs.macchiato/src/dirent.spec.ts
+++ b/packages/fs/fs.macchiato/src/dirent.spec.ts
@@ -1,13 +1,20 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 
 import Dirent from './dirent';
 
 describe('Dirent', () => {
+	it('should be instance of fs.Dirent', () => {
+		const dirent = new Dirent();
+
+		assert.ok(dirent instanceof fs.Dirent);
+	});
+
 	it('should create a fake instance without options', () => {
 		const dirent = new Dirent();
 
 		assert.strictEqual(dirent.name, 'unknown.txt');
-		assert.ok(dirent.isFile());
+		assert.ok(!dirent.isFile());
 		assert.ok(!dirent.isDirectory());
 		assert.ok(!dirent.isSymbolicLink());
 		assert.ok(!dirent.isBlockDevice());
@@ -20,7 +27,7 @@ describe('Dirent', () => {
 		const dirent = new Dirent({});
 
 		assert.strictEqual(dirent.name, 'unknown.txt');
-		assert.ok(dirent.isFile());
+		assert.ok(!dirent.isFile());
 		assert.ok(!dirent.isDirectory());
 		assert.ok(!dirent.isSymbolicLink());
 		assert.ok(!dirent.isBlockDevice());
@@ -33,7 +40,7 @@ describe('Dirent', () => {
 		const dirent = new Dirent({
 			name: 'known.txt',
 			isDirectory: true,
-			isFile: false,
+			isFile: true,
 			isSymbolicLink: true,
 			isBlockDevice: true,
 			isCharacterDevice: true,
@@ -42,7 +49,7 @@ describe('Dirent', () => {
 		});
 
 		assert.strictEqual(dirent.name, 'known.txt');
-		assert.ok(!dirent.isFile());
+		assert.ok(dirent.isFile());
 		assert.ok(dirent.isDirectory());
 		assert.ok(dirent.isSymbolicLink());
 		assert.ok(dirent.isBlockDevice());

--- a/packages/fs/fs.macchiato/src/dirent.ts
+++ b/packages/fs/fs.macchiato/src/dirent.ts
@@ -1,36 +1,41 @@
-import type * as fs from 'fs';
+import * as fs from 'fs';
+
 import type { PrepareOptionsFromClass } from './types';
 
-export default class Dirent implements fs.Dirent {
-	public readonly name: string = this._options.name ?? 'unknown.txt';
+type DirentOptions = PrepareOptionsFromClass<fs.Dirent>;
 
-	constructor(private readonly _options: PrepareOptionsFromClass<fs.Dirent> = {}) {}
+export default class Dirent extends fs.Dirent {
+	public override readonly name: string = this._options.name ?? 'unknown.txt';
 
-	public isFile(): boolean {
-		return this._options.isFile ?? true;
+	constructor(private readonly _options: DirentOptions = {}) {
+		super();
 	}
 
-	public isDirectory(): boolean {
+	public override isFile(): boolean {
+		return this._options.isFile ?? false;
+	}
+
+	public override isDirectory(): boolean {
 		return this._options.isDirectory ?? false;
 	}
 
-	public isBlockDevice(): boolean {
+	public override isBlockDevice(): boolean {
 		return this._options.isBlockDevice ?? false;
 	}
 
-	public isCharacterDevice(): boolean {
+	public override isCharacterDevice(): boolean {
 		return this._options.isCharacterDevice ?? false;
 	}
 
-	public isSymbolicLink(): boolean {
+	public override isSymbolicLink(): boolean {
 		return this._options.isSymbolicLink ?? false;
 	}
 
-	public isFIFO(): boolean {
+	public override isFIFO(): boolean {
 		return this._options.isFIFO ?? false;
 	}
 
-	public isSocket(): boolean {
+	public override isSocket(): boolean {
 		return this._options.isSocket ?? false;
 	}
 }

--- a/packages/fs/fs.macchiato/src/stats.spec.ts
+++ b/packages/fs/fs.macchiato/src/stats.spec.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 
 import Stats from './stats';
 
@@ -6,6 +7,12 @@ const uid = process.platform === 'win32' ? undefined : process.getuid();
 const gid = process.platform === 'win32' ? undefined : process.getgid();
 
 describe('Stats', () => {
+	it('should be instance of fs.Stats', () => {
+		const stats = new Stats();
+
+		assert.ok(stats instanceof fs.Stats);
+	});
+
 	it('should create a fake instance without options', () => {
 		const stats = new Stats();
 

--- a/packages/fs/fs.macchiato/src/stats.spec.ts
+++ b/packages/fs/fs.macchiato/src/stats.spec.ts
@@ -36,7 +36,7 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtime, date);
 		assert.strictEqual(stats.ctime, date);
 		assert.strictEqual(stats.birthtime, date);
-		assert.ok(stats.isFile());
+		assert.ok(!stats.isFile());
 		assert.ok(!stats.isDirectory());
 		assert.ok(!stats.isSymbolicLink());
 		assert.ok(!stats.isBlockDevice());
@@ -68,7 +68,7 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtime, date);
 		assert.strictEqual(stats.ctime, date);
 		assert.strictEqual(stats.birthtime, date);
-		assert.ok(stats.isFile());
+		assert.ok(!stats.isFile());
 		assert.ok(!stats.isDirectory());
 		assert.ok(!stats.isSymbolicLink());
 		assert.ok(!stats.isBlockDevice());
@@ -100,7 +100,7 @@ describe('Stats', () => {
 			ctime: date,
 			birthtime: date,
 			isDirectory: true,
-			isFile: false,
+			isFile: true,
 			isSymbolicLink: true,
 			isBlockDevice: true,
 			isCharacterDevice: true,
@@ -126,7 +126,7 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtime, date);
 		assert.strictEqual(stats.ctime, date);
 		assert.strictEqual(stats.birthtime, date);
-		assert.ok(!stats.isFile());
+		assert.ok(stats.isFile());
 		assert.ok(stats.isDirectory());
 		assert.ok(stats.isSymbolicLink());
 		assert.ok(stats.isBlockDevice());

--- a/packages/fs/fs.macchiato/src/stats.ts
+++ b/packages/fs/fs.macchiato/src/stats.ts
@@ -1,58 +1,63 @@
-import type * as fs from 'fs';
+import * as fs from 'fs';
+
 import type { PrepareOptionsFromClass } from './types';
 
 const uid = process.platform === 'win32' ? undefined : process.getuid();
 const gid = process.platform === 'win32' ? undefined : process.getgid();
 
-export default class Stats implements fs.Stats {
+type StatsOptions = PrepareOptionsFromClass<fs.Stats>;
+
+export default class Stats extends fs.Stats {
 	public readonly _date: Date = new Date();
 
-	public readonly dev: number = this._options.dev ?? 0;
-	public readonly ino: number = this._options.ino ?? 0;
-	public readonly mode: number = this._options.mode ?? 0;
-	public readonly nlink: number = this._options.nlink ?? 0;
-	public readonly uid: number = ('uid' in this._options ? this._options.uid : uid) as number;
-	public readonly gid: number = ('gid' in this._options ? this._options.gid : gid) as number;
-	public readonly rdev: number = this._options.rdev ?? 0;
-	public readonly size: number = this._options.size ?? 0;
-	public readonly blksize: number = this._options.blksize ?? 0;
-	public readonly blocks: number = this._options.blocks ?? 0;
-	public readonly atimeMs: number = this._options.atimeMs ?? this._date.getTime();
-	public readonly mtimeMs: number = this._options.mtimeMs ?? this._date.getTime();
-	public readonly ctimeMs: number = this._options.ctimeMs ?? this._date.getTime();
-	public readonly birthtimeMs: number = this._options.birthtimeMs ?? this._date.getTime();
-	public readonly atime: Date = this._options.atime ?? this._date;
-	public readonly mtime: Date = this._options.mtime ?? this._date;
-	public readonly ctime: Date = this._options.ctime ?? this._date;
-	public readonly birthtime: Date = this._options.birthtime ?? this._date;
+	public override readonly dev: number = this._options.dev ?? 0;
+	public override readonly ino: number = this._options.ino ?? 0;
+	public override readonly mode: number = this._options.mode ?? 0;
+	public override readonly nlink: number = this._options.nlink ?? 0;
+	public override readonly uid: number = ('uid' in this._options ? this._options.uid : uid) as number;
+	public override readonly gid: number = ('gid' in this._options ? this._options.gid : gid) as number;
+	public override readonly rdev: number = this._options.rdev ?? 0;
+	public override readonly size: number = this._options.size ?? 0;
+	public override readonly blksize: number = this._options.blksize ?? 0;
+	public override readonly blocks: number = this._options.blocks ?? 0;
+	public override readonly atimeMs: number = this._options.atimeMs ?? this._date.getTime();
+	public override readonly mtimeMs: number = this._options.mtimeMs ?? this._date.getTime();
+	public override readonly ctimeMs: number = this._options.ctimeMs ?? this._date.getTime();
+	public override readonly birthtimeMs: number = this._options.birthtimeMs ?? this._date.getTime();
+	public override readonly atime: Date = this._options.atime ?? this._date;
+	public override readonly mtime: Date = this._options.mtime ?? this._date;
+	public override readonly ctime: Date = this._options.ctime ?? this._date;
+	public override readonly birthtime: Date = this._options.birthtime ?? this._date;
 
-	constructor(private readonly _options: PrepareOptionsFromClass<fs.Stats> = {}) {}
+	constructor(private readonly _options: StatsOptions = {}) {
+		super();
+	}
 
-	public isFile(): boolean {
+	public override isFile(): boolean {
 		return this._options.isFile ?? true;
 	}
 
-	public isDirectory(): boolean {
+	public override isDirectory(): boolean {
 		return this._options.isDirectory ?? false;
 	}
 
-	public isBlockDevice(): boolean {
+	public override isBlockDevice(): boolean {
 		return this._options.isBlockDevice ?? false;
 	}
 
-	public isCharacterDevice(): boolean {
+	public override isCharacterDevice(): boolean {
 		return this._options.isCharacterDevice ?? false;
 	}
 
-	public isSymbolicLink(): boolean {
+	public override isSymbolicLink(): boolean {
 		return this._options.isSymbolicLink ?? false;
 	}
 
-	public isFIFO(): boolean {
+	public override isFIFO(): boolean {
 		return this._options.isFIFO ?? false;
 	}
 
-	public isSocket(): boolean {
+	public override isSocket(): boolean {
 		return this._options.isSocket ?? false;
 	}
 }

--- a/packages/fs/fs.macchiato/src/stats.ts
+++ b/packages/fs/fs.macchiato/src/stats.ts
@@ -34,7 +34,7 @@ export default class Stats extends fs.Stats {
 	}
 
 	public override isFile(): boolean {
-		return this._options.isFile ?? true;
+		return this._options.isFile ?? false;
 	}
 
 	public override isDirectory(): boolean {

--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -16,7 +16,7 @@ const read = util.promisify(provider.read);
 describe('Providers → Async', () => {
 	describe('.read', () => {
 		it('should return entries', async () => {
-			const dirent = new Dirent({ name: 'file.txt' });
+			const dirent = new Dirent({ name: 'file.txt', isFile: true });
 
 			const readdir = sinon.stub().yields(null, [dirent]);
 
@@ -36,7 +36,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return entries with the "stats" property', async () => {
-			const dirent = new Dirent({ name: 'file.txt' });
+			const dirent = new Dirent({ name: 'file.txt', isFile: true });
 			const stats = new Stats();
 
 			const readdir = sinon.stub().yields(null, [dirent]);

--- a/packages/fs/fs.scandir/src/providers/sync.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.spec.ts
@@ -13,7 +13,7 @@ import type { Entry } from '../types';
 describe('Providers → Sync', () => {
 	describe('.read', () => {
 		it('should return entries', () => {
-			const dirent = new Dirent({ name: 'file.txt' });
+			const dirent = new Dirent({ name: 'file.txt', isFile: true });
 
 			const readdirSync = sinon.stub().returns([dirent]);
 
@@ -33,7 +33,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return entries with the "stats" property', () => {
-			const dirent = new Dirent({ name: 'file.txt' });
+			const dirent = new Dirent({ name: 'file.txt', isFile: true });
 			const stats = new Stats();
 
 			const readdirSync = sinon.stub().returns([dirent]);

--- a/packages/fs/fs.scandir/src/utils/fs.spec.ts
+++ b/packages/fs/fs.scandir/src/utils/fs.spec.ts
@@ -14,7 +14,7 @@ describe('Utils → FS', () => {
 			assert.ok(!actual.isCharacterDevice());
 			assert.ok(!actual.isDirectory());
 			assert.ok(!actual.isFIFO());
-			assert.ok(actual.isFile());
+			assert.ok(!actual.isFile());
 			assert.ok(!actual.isSocket());
 			assert.ok(!actual.isSymbolicLink());
 		});

--- a/packages/fs/fs.walk/src/tests/index.ts
+++ b/packages/fs/fs.walk/src/tests/index.ts
@@ -7,7 +7,7 @@ export function buildFakeFileEntry(entry?: Partial<Entry>): Entry {
 	return {
 		name: 'fake.txt',
 		path: 'directory/fake.txt',
-		dirent: new Dirent({ name: 'fake.txt' }),
+		dirent: new Dirent({ name: 'fake.txt', isFile: true }),
 		...entry,
 	};
 }
@@ -16,7 +16,7 @@ export function buildFakeDirectoryEntry(entry?: Partial<Entry>): Entry {
 	return {
 		name: 'fake',
 		path: 'directory/fake',
-		dirent: new Dirent({ name: 'fake', isFile: false, isDirectory: true }),
+		dirent: new Dirent({ name: 'fake', isDirectory: true }),
 		...entry,
 	};
 }


### PR DESCRIPTION
### What is the purpose of this pull request?

Fake instances of classes are inherited from the original ones to avoid problems with `instanceof` in the production code.

### What changes did you make? (Give an overview)
…
