### PR TITLE
Use native implementation of fs.Dirent and fs.Stats

### DIFF
--- a/packages/fs/fs.macchiato/README.md
+++ b/packages/fs/fs.macchiato/README.md
@@ -11,9 +11,9 @@ $ npm install @nodelib/fs.macchiato
 ## Usage
 
 ```js
-import { Stats, Dirent, DirentType } from '@nodelib/fs.macchiato';
+import { Stats, StatsMode, Dirent, DirentType } from '@nodelib/fs.macchiato';
 
-const stats = new Stats();
+const stats = new Stats({ mode: StatsMode.File });
 const dirent = new Dirent('file.txt', DirentType.File);
 ```
 
@@ -25,7 +25,7 @@ Creates a fake instance of `fs.Stats`. Can accept options to control parameter v
 
 ```js
 const stats = new Stats({
-	isSymbolicLink: true,
+	mode: StatsMode.File,
 	ino: 3
 });
 ```

--- a/packages/fs/fs.macchiato/README.md
+++ b/packages/fs/fs.macchiato/README.md
@@ -11,10 +11,10 @@ $ npm install @nodelib/fs.macchiato
 ## Usage
 
 ```js
-import { Stats, Dirent } from '@nodelib/fs.macchiato';
+import { Stats, Dirent, DirentType } from '@nodelib/fs.macchiato';
 
 const stats = new Stats();
-const dirent = new Dirent();
+const dirent = new Dirent('file.txt', DirentType.File);
 ```
 
 ## API
@@ -35,9 +35,7 @@ const stats = new Stats({
 Creates a fake instance of `fs.Dirent`. Can accept options to control parameter values.
 
 ```js
-const dirent = new Dirent({
-	isSymbolicLink: true
-});
+const dirent = new Dirent('file.txt', DirentType.Link);
 ```
 
 ## Changelog

--- a/packages/fs/fs.macchiato/src/dirent.spec.ts
+++ b/packages/fs/fs.macchiato/src/dirent.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 
-import Dirent from './dirent';
+import { Dirent, DirentType } from './dirent';
 
 describe('Dirent', () => {
 	it('should be instance of fs.Dirent', () => {
@@ -23,38 +23,16 @@ describe('Dirent', () => {
 		assert.ok(!dirent.isSocket());
 	});
 
-	it('should create a fake instance with empty options', () => {
-		const dirent = new Dirent({});
+	it('should create a fake instance with options', () => {
+		const dirent = new Dirent('known.txt', DirentType.File);
 
-		assert.strictEqual(dirent.name, 'unknown.txt');
-		assert.ok(!dirent.isFile());
+		assert.strictEqual(dirent.name, 'known.txt');
+		assert.ok(dirent.isFile());
 		assert.ok(!dirent.isDirectory());
 		assert.ok(!dirent.isSymbolicLink());
 		assert.ok(!dirent.isBlockDevice());
 		assert.ok(!dirent.isCharacterDevice());
 		assert.ok(!dirent.isFIFO());
 		assert.ok(!dirent.isSocket());
-	});
-
-	it('should create a fake instance with options', () => {
-		const dirent = new Dirent({
-			name: 'known.txt',
-			isDirectory: true,
-			isFile: true,
-			isSymbolicLink: true,
-			isBlockDevice: true,
-			isCharacterDevice: true,
-			isFIFO: true,
-			isSocket: true,
-		});
-
-		assert.strictEqual(dirent.name, 'known.txt');
-		assert.ok(dirent.isFile());
-		assert.ok(dirent.isDirectory());
-		assert.ok(dirent.isSymbolicLink());
-		assert.ok(dirent.isBlockDevice());
-		assert.ok(dirent.isCharacterDevice());
-		assert.ok(dirent.isFIFO());
-		assert.ok(dirent.isSocket());
 	});
 });

--- a/packages/fs/fs.macchiato/src/dirent.ts
+++ b/packages/fs/fs.macchiato/src/dirent.ts
@@ -1,41 +1,21 @@
 import * as fs from 'fs';
 
-import type { PrepareOptionsFromClass } from './types';
+// https://github.com/nodejs/node/blob/6675505686310771b8016805a381945826aad887/typings/internalBinding/constants.d.ts#L139-L146
+export enum DirentType {
+	Unknown = 0,
+	File = 1,
+	Directory = 2,
+	Link = 3,
+	Fifo = 4,
+	Socket = 5,
+	Char = 6,
+	Block = 7,
+}
 
-type DirentOptions = PrepareOptionsFromClass<fs.Dirent>;
-
-export default class Dirent extends fs.Dirent {
-	public override readonly name: string = this._options.name ?? 'unknown.txt';
-
-	constructor(private readonly _options: DirentOptions = {}) {
-		super();
-	}
-
-	public override isFile(): boolean {
-		return this._options.isFile ?? false;
-	}
-
-	public override isDirectory(): boolean {
-		return this._options.isDirectory ?? false;
-	}
-
-	public override isBlockDevice(): boolean {
-		return this._options.isBlockDevice ?? false;
-	}
-
-	public override isCharacterDevice(): boolean {
-		return this._options.isCharacterDevice ?? false;
-	}
-
-	public override isSymbolicLink(): boolean {
-		return this._options.isSymbolicLink ?? false;
-	}
-
-	public override isFIFO(): boolean {
-		return this._options.isFIFO ?? false;
-	}
-
-	public override isSocket(): boolean {
-		return this._options.isSocket ?? false;
+export class Dirent extends fs.Dirent {
+	constructor(name: string = 'unknown.txt', type: DirentType = DirentType.Unknown) {
+		// @ts-expect-error Types do not provide arguments.
+		// https://github.com/nodejs/node/blob/6675505686310771b8016805a381945826aad887/lib/internal/fs/utils.js#L164
+		super(name, type);
 	}
 }

--- a/packages/fs/fs.macchiato/src/index.ts
+++ b/packages/fs/fs.macchiato/src/index.ts
@@ -1,2 +1,2 @@
-export { default as Dirent } from './dirent';
+export { Dirent, DirentType } from './dirent';
 export { default as Stats } from './stats';

--- a/packages/fs/fs.macchiato/src/index.ts
+++ b/packages/fs/fs.macchiato/src/index.ts
@@ -1,2 +1,2 @@
 export { Dirent, DirentType } from './dirent';
-export { default as Stats } from './stats';
+export { Stats, StatsMode } from './stats';

--- a/packages/fs/fs.macchiato/src/stats.spec.ts
+++ b/packages/fs/fs.macchiato/src/stats.spec.ts
@@ -1,10 +1,12 @@
 import * as assert from 'assert';
 import * as fs from 'fs';
 
-import Stats from './stats';
+import { Stats, StatsMode } from './stats';
 
-const uid = process.platform === 'win32' ? undefined : process.getuid();
-const gid = process.platform === 'win32' ? undefined : process.getgid();
+const isWindows = process.platform === 'win32';
+
+const uid = isWindows ? undefined : process.getuid();
+const gid = isWindows ? undefined : process.getgid();
 
 describe('Stats', () => {
 	it('should be instance of fs.Stats', () => {
@@ -16,7 +18,7 @@ describe('Stats', () => {
 	it('should create a fake instance without options', () => {
 		const stats = new Stats();
 
-		const date = stats._date;
+		const date = new Date();
 
 		assert.strictEqual(stats.dev, 0);
 		assert.strictEqual(stats.ino, 0);
@@ -32,10 +34,10 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtimeMs, date.getTime());
 		assert.strictEqual(stats.ctimeMs, date.getTime());
 		assert.strictEqual(stats.birthtimeMs, date.getTime());
-		assert.strictEqual(stats.atime, date);
-		assert.strictEqual(stats.mtime, date);
-		assert.strictEqual(stats.ctime, date);
-		assert.strictEqual(stats.birthtime, date);
+		assert.deepStrictEqual(stats.atime, date);
+		assert.deepStrictEqual(stats.mtime, date);
+		assert.deepStrictEqual(stats.ctime, date);
+		assert.deepStrictEqual(stats.birthtime, date);
 		assert.ok(!stats.isFile());
 		assert.ok(!stats.isDirectory());
 		assert.ok(!stats.isSymbolicLink());
@@ -48,11 +50,11 @@ describe('Stats', () => {
 	it('should create a fake instance with empty options', () => {
 		const stats = new Stats();
 
-		const date = stats._date;
+		const date = new Date();
 
 		assert.strictEqual(stats.dev, 0);
 		assert.strictEqual(stats.ino, 0);
-		assert.strictEqual(stats.mode, 0);
+		assert.strictEqual(stats.mode, StatsMode.Unknown);
 		assert.strictEqual(stats.nlink, 0);
 		assert.strictEqual(stats.uid, uid);
 		assert.strictEqual(stats.gid, gid);
@@ -64,10 +66,10 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtimeMs, date.getTime());
 		assert.strictEqual(stats.ctimeMs, date.getTime());
 		assert.strictEqual(stats.birthtimeMs, date.getTime());
-		assert.strictEqual(stats.atime, date);
-		assert.strictEqual(stats.mtime, date);
-		assert.strictEqual(stats.ctime, date);
-		assert.strictEqual(stats.birthtime, date);
+		assert.deepStrictEqual(stats.atime, date);
+		assert.deepStrictEqual(stats.mtime, date);
+		assert.deepStrictEqual(stats.ctime, date);
+		assert.deepStrictEqual(stats.birthtime, date);
 		assert.ok(!stats.isFile());
 		assert.ok(!stats.isDirectory());
 		assert.ok(!stats.isSymbolicLink());
@@ -83,7 +85,7 @@ describe('Stats', () => {
 		const stats = new Stats({
 			dev: 1,
 			ino: 1,
-			mode: 1,
+			mode: StatsMode.Directory,
 			nlink: 1,
 			uid: 1,
 			gid: 1,
@@ -99,18 +101,11 @@ describe('Stats', () => {
 			mtime: date,
 			ctime: date,
 			birthtime: date,
-			isDirectory: true,
-			isFile: true,
-			isSymbolicLink: true,
-			isBlockDevice: true,
-			isCharacterDevice: true,
-			isFIFO: true,
-			isSocket: true,
 		});
 
 		assert.strictEqual(stats.dev, 1);
 		assert.strictEqual(stats.ino, 1);
-		assert.strictEqual(stats.mode, 1);
+		assert.strictEqual(stats.mode, StatsMode.Directory);
 		assert.strictEqual(stats.nlink, 1);
 		assert.strictEqual(stats.uid, 1);
 		assert.strictEqual(stats.gid, 1);
@@ -122,24 +117,26 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtimeMs, date.getTime());
 		assert.strictEqual(stats.ctimeMs, date.getTime());
 		assert.strictEqual(stats.birthtimeMs, date.getTime());
-		assert.strictEqual(stats.atime, date);
-		assert.strictEqual(stats.mtime, date);
-		assert.strictEqual(stats.ctime, date);
-		assert.strictEqual(stats.birthtime, date);
-		assert.ok(stats.isFile());
+		assert.deepStrictEqual(stats.atime, date);
+		assert.deepStrictEqual(stats.mtime, date);
+		assert.deepStrictEqual(stats.ctime, date);
+		assert.deepStrictEqual(stats.birthtime, date);
+		assert.ok(!stats.isFile());
 		assert.ok(stats.isDirectory());
-		assert.ok(stats.isSymbolicLink());
-		assert.ok(stats.isBlockDevice());
-		assert.ok(stats.isCharacterDevice());
-		assert.ok(stats.isFIFO());
-		assert.ok(stats.isSocket());
+		assert.ok(!stats.isSymbolicLink());
+		assert.ok(!stats.isBlockDevice());
+		assert.ok(!stats.isCharacterDevice());
+		assert.ok(!stats.isFIFO());
+		assert.ok(!stats.isSocket());
 	});
 
 	it('should create a fake instance with undefined as values', () => {
 		const stats = new Stats({
 			uid: undefined,
+			gid: undefined,
 		});
 
 		assert.strictEqual(stats.uid, undefined);
+		assert.strictEqual(stats.gid, undefined);
 	});
 });

--- a/packages/fs/fs.macchiato/src/stats.ts
+++ b/packages/fs/fs.macchiato/src/stats.ts
@@ -2,62 +2,48 @@ import * as fs from 'fs';
 
 import type { PrepareOptionsFromClass } from './types';
 
-const uid = process.platform === 'win32' ? undefined : process.getuid();
-const gid = process.platform === 'win32' ? undefined : process.getgid();
+const isWindows = process.platform === 'win32';
 
-type StatsOptions = PrepareOptionsFromClass<fs.Stats>;
+const uid = isWindows ? undefined : process.getuid();
+const gid = isWindows ? undefined : process.getgid();
 
-export default class Stats extends fs.Stats {
-	public readonly _date: Date = new Date();
+// https://github.com/nodejs/node/blob/6675505686310771b8016805a381945826aad887/typings/internalBinding/constants.d.ts#L148-L154
+export enum StatsMode {
+	Unknown = 0,
+	File = 32_768,
+	Directory = 16_384,
+	Link = 40_960,
+	Fifo = 4096,
+	Socket = 49_152,
+	Char = 8192,
+	Block = 24_576,
+}
 
-	public override readonly dev: number = this._options.dev ?? 0;
-	public override readonly ino: number = this._options.ino ?? 0;
-	public override readonly mode: number = this._options.mode ?? 0;
-	public override readonly nlink: number = this._options.nlink ?? 0;
-	public override readonly uid: number = ('uid' in this._options ? this._options.uid : uid) as number;
-	public override readonly gid: number = ('gid' in this._options ? this._options.gid : gid) as number;
-	public override readonly rdev: number = this._options.rdev ?? 0;
-	public override readonly size: number = this._options.size ?? 0;
-	public override readonly blksize: number = this._options.blksize ?? 0;
-	public override readonly blocks: number = this._options.blocks ?? 0;
-	public override readonly atimeMs: number = this._options.atimeMs ?? this._date.getTime();
-	public override readonly mtimeMs: number = this._options.mtimeMs ?? this._date.getTime();
-	public override readonly ctimeMs: number = this._options.ctimeMs ?? this._date.getTime();
-	public override readonly birthtimeMs: number = this._options.birthtimeMs ?? this._date.getTime();
-	public override readonly atime: Date = this._options.atime ?? this._date;
-	public override readonly mtime: Date = this._options.mtime ?? this._date;
-	public override readonly ctime: Date = this._options.ctime ?? this._date;
-	public override readonly birthtime: Date = this._options.birthtime ?? this._date;
+type StatsOptions = PrepareOptionsFromClass<fs.Stats> & {
+	mode?: StatsMode;
+};
 
-	constructor(private readonly _options: StatsOptions = {}) {
-		super();
-	}
+export class Stats extends fs.Stats implements fs.Stats {
+	constructor(options: StatsOptions = {}) {
+		const date = new Date();
 
-	public override isFile(): boolean {
-		return this._options.isFile ?? false;
-	}
-
-	public override isDirectory(): boolean {
-		return this._options.isDirectory ?? false;
-	}
-
-	public override isBlockDevice(): boolean {
-		return this._options.isBlockDevice ?? false;
-	}
-
-	public override isCharacterDevice(): boolean {
-		return this._options.isCharacterDevice ?? false;
-	}
-
-	public override isSymbolicLink(): boolean {
-		return this._options.isSymbolicLink ?? false;
-	}
-
-	public override isFIFO(): boolean {
-		return this._options.isFIFO ?? false;
-	}
-
-	public override isSocket(): boolean {
-		return this._options.isSocket ?? false;
+		super(
+			// @ts-expect-error Types do not provide arguments.
+			// https://github.com/nodejs/node/blob/6675505686310771b8016805a381945826aad887/lib/internal/fs/utils.js#L501-L503
+			options.dev ?? 0,
+			options.mode ?? StatsMode.Unknown,
+			options.nlink ?? 0,
+			'uid' in options ? options.uid : uid,
+			'gid' in options ? options.gid : gid,
+			options.rdev ?? 0,
+			options.blksize ?? 0,
+			options.ino ?? 0,
+			options.size ?? 0,
+			options.blocks ?? 0,
+			options.atimeMs ?? date.getTime(),
+			options.mtimeMs ?? date.getTime(),
+			options.ctimeMs ?? date.getTime(),
+			options.birthtimeMs ?? date.getTime(),
+		);
 	}
 }

--- a/packages/fs/fs.macchiato/src/types.ts
+++ b/packages/fs/fs.macchiato/src/types.ts
@@ -1,17 +1,7 @@
 export type PrepareOptionsFromClass<T> = {
-	[TKey in keyof T]?: UnboxReturnTypeFromClassItem<T[TKey]>;
+	[TKey in NonFunctionPropertyNames<T>]?: T[TKey];
 };
 
-export type UnboxReturnTypeFromClassItem<T> =
-	/**
-	 * Unbox return type from class method.
-	 */
-	T extends (...args: unknown[]) => infer TReturnType ? TReturnType :
-		/**
-		 * Unbox return type from class property.
-		 */
-		T extends (infer TReturnType) ? TReturnType :
-			/**
-			 * Default branch. Potentially impossible case.
-			 */
-			T;
+type NonFunctionPropertyNames<T> = {
+	[TKey in keyof T]: T[TKey] extends () => unknown ? never : TKey;
+}[keyof T];

--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as util from 'util';
 
 import * as sinon from 'sinon';
-import { Dirent, DirentType, Stats } from '@nodelib/fs.macchiato';
+import { Dirent, DirentType, Stats, StatsMode } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as utils from '../utils';
@@ -64,7 +64,7 @@ describe('Providers → Async', () => {
 			const stats = new Stats();
 
 			const readdir = sinon.stub().yields(null, [dirent]);
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 			const stat = sinon.stub().yields(null, stats);
 
 			const settings = new Settings({

--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as util from 'util';
 
 import * as sinon from 'sinon';
-import { Dirent, Stats } from '@nodelib/fs.macchiato';
+import { Dirent, DirentType, Stats } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as utils from '../utils';
@@ -16,7 +16,7 @@ const read = util.promisify(provider.read);
 describe('Providers → Async', () => {
 	describe('.read', () => {
 		it('should return entries', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isFile: true });
+			const dirent = new Dirent('file.txt', DirentType.File);
 
 			const readdir = sinon.stub().yields(null, [dirent]);
 
@@ -36,7 +36,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return entries with the "stats" property', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isFile: true });
+			const dirent = new Dirent('file.txt', DirentType.File);
 			const stats = new Stats();
 
 			const readdir = sinon.stub().yields(null, [dirent]);
@@ -60,7 +60,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should update Dirent when the "stats" and "followSymbolicLinks" options are enabled', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
 			const readdir = sinon.stub().yields(null, [dirent]);
@@ -86,7 +86,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should update Dirent when the "followSymbolicLinks" option is enabled', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
 			const readdir = sinon.stub().yields(null, [dirent]);
@@ -109,7 +109,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should do nothing with symbolic links when the "followSymbolicLinks" option is disabled', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdir = sinon.stub().yields(null, [dirent]);
 
@@ -129,7 +129,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdir = sinon.stub().yields(null, [dirent]);
 			const stat = sinon.stub().yields(new Error('error'));
@@ -152,7 +152,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should throw an error for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', async () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdir = sinon.stub().yields(null, [dirent]);
 			const stat = sinon.stub().yields(new Error('error'));

--- a/packages/fs/fs.scandir/src/providers/sync.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.spec.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 import * as sinon from 'sinon';
-import { Dirent, DirentType, Stats } from '@nodelib/fs.macchiato';
+import { Dirent, DirentType, Stats, StatsMode } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as utils from '../utils';
@@ -61,7 +61,7 @@ describe('Providers → Sync', () => {
 			const stats = new Stats();
 
 			const readdirSync = sinon.stub().returns([dirent]);
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 			const statSync = sinon.stub().returns(stats);
 
 			const settings = new Settings({

--- a/packages/fs/fs.scandir/src/providers/sync.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.spec.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as path from 'path';
 
 import * as sinon from 'sinon';
-import { Dirent, Stats } from '@nodelib/fs.macchiato';
+import { Dirent, DirentType, Stats } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as utils from '../utils';
@@ -13,7 +13,7 @@ import type { Entry } from '../types';
 describe('Providers → Sync', () => {
 	describe('.read', () => {
 		it('should return entries', () => {
-			const dirent = new Dirent({ name: 'file.txt', isFile: true });
+			const dirent = new Dirent('file.txt', DirentType.File);
 
 			const readdirSync = sinon.stub().returns([dirent]);
 
@@ -33,7 +33,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return entries with the "stats" property', () => {
-			const dirent = new Dirent({ name: 'file.txt', isFile: true });
+			const dirent = new Dirent('file.txt', DirentType.File);
 			const stats = new Stats();
 
 			const readdirSync = sinon.stub().returns([dirent]);
@@ -57,7 +57,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should update Dirent when the "stats" and "followSymbolicLinks" options are enabled', () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
 			const readdirSync = sinon.stub().returns([dirent]);
@@ -83,7 +83,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should update Dirent when the "followSymbolicLinks" option is enabled', () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
 			const readdirSync = sinon.stub().returns([dirent]);
@@ -106,7 +106,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should do nothing with symbolic links when the "followSymbolicLinks" option is disabled', () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdirSync = sinon.stub().returns([dirent]);
 
@@ -126,7 +126,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdirSync = sinon.stub().returns([dirent]);
 			const statSync = sinon.stub().throws(new Error('error'));
@@ -149,7 +149,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should throw an error for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', () => {
-			const dirent = new Dirent({ name: 'file.txt', isSymbolicLink: true });
+			const dirent = new Dirent('file.txt', DirentType.Link);
 
 			const readdirSync = sinon.stub().returns([dirent]);
 			const statSync = sinon.stub().throws(new Error('error'));

--- a/packages/fs/fs.stat/src/providers/async.spec.ts
+++ b/packages/fs/fs.stat/src/providers/async.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 
 import * as sinon from 'sinon';
-import { Stats } from '@nodelib/fs.macchiato';
+import { Stats, StatsMode } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as provider from './async';
@@ -23,7 +23,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return lstat for symlink entry when the "followSymbolicLink" option is disabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 
 			const settings = new Settings({
 				followSymbolicLink: false,
@@ -38,7 +38,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return stat for symlink entry', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 			const stat = sinon.stub().yields(null, new Stats({ ino: 1 }));
 
 			const settings = new Settings({
@@ -53,7 +53,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return marked stat for symlink entry when the "markSymbolicLink" option is enabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 			const stat = sinon.stub().yields(null, new Stats({ ino: 1 }));
 
 			const settings = new Settings({
@@ -69,7 +69,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should return lstat for broken symlink entry when the "throwErrorOnBrokenSymbolicLink" option is disabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 			const stat = sinon.stub().yields(new Error('error_message'));
 
 			const settings = new Settings({
@@ -85,7 +85,7 @@ describe('Providers → Async', () => {
 		});
 
 		it('should throw an error when symlink entry is broken', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ isSymbolicLink: true }));
+			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
 			const stat = sinon.stub().yields(new Error('broken'));
 
 			const settings = new Settings({

--- a/packages/fs/fs.stat/src/providers/sync.spec.ts
+++ b/packages/fs/fs.stat/src/providers/sync.spec.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 
 import * as sinon from 'sinon';
-import { Stats } from '@nodelib/fs.macchiato';
+import { Stats, StatsMode } from '@nodelib/fs.macchiato';
 
 import Settings from '../settings';
 import * as provider from './sync';
@@ -21,7 +21,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return lstat for symlink entry when the "followSymbolicLink" option is disabled', () => {
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 
 			const settings = new Settings({
 				followSymbolicLink: false,
@@ -34,7 +34,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return stat for symlink entry', () => {
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 			const statSync = sinon.stub().returns(new Stats({ ino: 1 }));
 
 			const settings = new Settings({
@@ -47,7 +47,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return marked stat for symlink entry when the "markSymbolicLink" option is enabled', () => {
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 			const statSync = sinon.stub().returns(new Stats({ ino: 1 }));
 
 			const settings = new Settings({
@@ -61,7 +61,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should return lstat for broken symlink entry when the "throwErrorOnBrokenSymbolicLink" option is disabled', () => {
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 			const statSync = sinon.stub().throws(new Error('error'));
 
 			const settings = new Settings({
@@ -75,7 +75,7 @@ describe('Providers → Sync', () => {
 		});
 
 		it('should throw an error when symlink entry is broken', () => {
-			const lstatSync = sinon.stub().returns(new Stats({ isSymbolicLink: true }));
+			const lstatSync = sinon.stub().returns(new Stats({ mode: StatsMode.Link }));
 			const statSync = sinon.stub().throws(new Error('broken'));
 
 			const settings = new Settings({

--- a/packages/fs/fs.walk/src/tests/index.ts
+++ b/packages/fs/fs.walk/src/tests/index.ts
@@ -1,5 +1,5 @@
 import * as sinon from 'sinon';
-import { Dirent } from '@nodelib/fs.macchiato';
+import { Dirent, DirentType } from '@nodelib/fs.macchiato';
 
 import type { Entry, Errno } from '../types';
 
@@ -7,7 +7,7 @@ export function buildFakeFileEntry(entry?: Partial<Entry>): Entry {
 	return {
 		name: 'fake.txt',
 		path: 'directory/fake.txt',
-		dirent: new Dirent({ name: 'fake.txt', isFile: true }),
+		dirent: new Dirent('fake.txt', DirentType.File),
 		...entry,
 	};
 }
@@ -16,7 +16,7 @@ export function buildFakeDirectoryEntry(entry?: Partial<Entry>): Entry {
 	return {
 		name: 'fake',
 		path: 'directory/fake',
-		dirent: new Dirent({ name: 'fake', isDirectory: true }),
+		dirent: new Dirent('fake', DirentType.Directory),
 		...entry,
 	};
 }


### PR DESCRIPTION
- refactor(fs.macchiato): provide native implementation of fs.Dirent
- refactor(fs.macchiato): provide native implementation of fs.Stats

### What is the purpose of this pull request?
…

### What changes did you make? (Give an overview)
…
