### PR TITLE
Do not throw an error when reader has alredy been destroyed

### DIFF
--- a/packages/fs/fs.walk/src/readers/async.spec.ts
+++ b/packages/fs/fs.walk/src/readers/async.spec.ts
@@ -218,16 +218,14 @@ describe('Readers → Async', () => {
 			assert.ok(reader.isDestroyed);
 		});
 
-		it('should throw an error when trying to destroy reader twice', () => {
+		it('should do nothing when trying to destroy reader twice', () => {
 			const reader = new TestReader();
-
-			const expectedErrorMessageRe = /The reader is already destroyed/;
 
 			reader.destroy();
 
-			assert.throws(() => {
+			assert.doesNotThrow(() => {
 				reader.destroy();
-			}, expectedErrorMessageRe);
+			});
 		});
 	});
 });

--- a/packages/fs/fs.walk/src/readers/async.ts
+++ b/packages/fs/fs.walk/src/readers/async.ts
@@ -85,7 +85,7 @@ export class AsyncReader extends AsyncReaderEmitter implements IAsyncReader {
 
 	public destroy(): void {
 		if (this.#isDestroyed) {
-			throw new Error('The reader is already destroyed');
+			return;
 		}
 
 		this.#isDestroyed = true;


### PR DESCRIPTION
### What is the purpose of this pull request?

https://nodejs.org/dist/latest-v20.x/docs/api/stream.html#readabledestroyerror

> Work as a no-op on a stream that has already been destroyed.

### What changes did you make? (Give an overview)
…
