### PR TITLE
Fix fs.walkStream to properly end async iterators

### DIFF
--- a/packages/fs/fs.walk/src/providers/stream.ts
+++ b/packages/fs/fs.walk/src/providers/stream.ts
@@ -33,10 +33,12 @@ export class StreamProvider {
 		return new Readable({
 			objectMode: true,
 			read: () => { /* noop */ },
-			destroy: () => {
+			destroy: (error, callback) => {
 				if (!this.#reader.isDestroyed) {
 					this.#reader.destroy();
 				}
+
+				callback(error);
 			},
 		});
 	}


### PR DESCRIPTION
### What is the purpose of this pull request?

Attempting to use `walkStream`'s returned `stream.Readable` as an async iterator leads to loops that never complete:
```js
for await (const entry of walkStream(".")) {}
console.log("Never happens");
```

### What changes did you make? (Give an overview)

Fixed StreamProvider's custom `destroy()` implementation to use the `callback` parameter which is required to correctly finish the stream.

Added a `'should support async iteration'` test which demonstrates the issue on master, but works with this change.  