### PR TITLE
Convert fs.stat and fs.scandir to promise-based API

### DIFF
--- a/packages/fs/fs.scandir/package.json
+++ b/packages/fs/fs.scandir/package.json
@@ -37,8 +37,7 @@
     "bench:async": "hereby bench:async"
   },
   "dependencies": {
-    "@nodelib/fs.stat": "3.0.0",
-    "run-parallel": "^1.2.0"
+    "@nodelib/fs.stat": "3.0.0"
   },
   "devDependencies": {
     "@nodelib/fs.macchiato": "2.0.0",

--- a/packages/fs/fs.scandir/src/adapters/fs.ts
+++ b/packages/fs/fs.scandir/src/adapters/fs.ts
@@ -1,9 +1,9 @@
 import * as fs from 'node:fs';
 
 import type * as fsStat from '@nodelib/fs.stat';
-import type { Dirent, ErrnoException } from '../types';
+import type { Dirent } from '../types';
 
-export type ReaddirAsynchronousMethod = (filepath: string, options: { withFileTypes: true }, callback: (error: ErrnoException | null, files: Dirent[]) => void) => void;
+export type ReaddirAsynchronousMethod = (filepath: string, options: { withFileTypes: true }) => Promise<Dirent[]>;
 export type ReaddirSynchronousMethod = (filepath: string, options: { withFileTypes: true }) => Dirent[];
 
 export type FileSystemAdapter = fsStat.FileSystemAdapter & {
@@ -12,11 +12,11 @@ export type FileSystemAdapter = fsStat.FileSystemAdapter & {
 };
 
 export const FILE_SYSTEM_ADAPTER: FileSystemAdapter = {
-	lstat: fs.lstat,
-	stat: fs.stat,
+	lstat: fs.promises.lstat,
+	stat: fs.promises.stat,
 	lstatSync: fs.lstatSync,
 	statSync: fs.statSync,
-	readdir: fs.readdir,
+	readdir: fs.promises.readdir,
 	readdirSync: fs.readdirSync,
 };
 

--- a/packages/fs/fs.scandir/src/benchmark/suites/async.ts
+++ b/packages/fs/fs.scandir/src/benchmark/suites/async.ts
@@ -7,15 +7,17 @@ import * as utils from '../utils';
 
 import type { Options } from '@nodelib/fs.scandir.previous';
 
+type BenchOptions = Omit<Options, 'fs'>;
+
 type ScandirImplementation = 'current' | 'previous';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScandirImplFunction = (...args: any[]) => Promise<unknown[]>;
 
 class Scandir {
 	readonly #cwd: string;
-	readonly #options: Options;
+	readonly #options: BenchOptions;
 
-	constructor(cwd: string, options: Options) {
+	constructor(cwd: string, options: BenchOptions) {
 		this.#cwd = cwd;
 		this.#options = options;
 	}
@@ -33,7 +35,7 @@ class Scandir {
 		const scandir = await utils.importAndMeasure(utils.importCurrent);
 		const settings = new scandir.Settings(this.#options);
 
-		const action = util.promisify(scandir.scandir);
+		const action = scandir.scandir;
 
 		await this.#measure(() => action(this.#cwd, settings));
 	}

--- a/packages/fs/fs.scandir/src/benchmark/suites/sync.ts
+++ b/packages/fs/fs.scandir/src/benchmark/suites/sync.ts
@@ -6,15 +6,17 @@ import * as utils from '../utils';
 
 import type { Options } from '@nodelib/fs.scandir.previous';
 
+type BenchOptions = Omit<Options, 'fs'>;
+
 type ScandirImplementation = 'current' | 'previous';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ScandirImplFunction = (...args: any[]) => unknown[];
 
 class Scandir {
 	readonly #cwd: string;
-	readonly #options: Options;
+	readonly #options: BenchOptions;
 
-	constructor(cwd: string, options: Options) {
+	constructor(cwd: string, options: BenchOptions) {
 		this.#cwd = cwd;
 		this.#options = options;
 	}

--- a/packages/fs/fs.scandir/src/index.ts
+++ b/packages/fs/fs.scandir/src/index.ts
@@ -2,5 +2,5 @@ export { scandir, scandirSync } from './scandir';
 export { Settings } from './settings';
 
 export type { FileSystemAdapter, ReaddirSynchronousMethod, ReaddirAsynchronousMethod } from './adapters/fs';
-export type { Dirent, Entry, AsyncCallback } from './types';
+export type { Dirent, Entry } from './types';
 export type { Options } from './settings';

--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -1,6 +1,5 @@
 import * as assert from 'node:assert';
 import * as path from 'node:path';
-import * as util from 'node:util';
 
 import * as sinon from 'sinon';
 import { Dirent, DirentType, Stats, StatsMode } from '@nodelib/fs.macchiato';
@@ -11,14 +10,14 @@ import * as provider from './async';
 
 import type { Entry } from '../types';
 
-const read = util.promisify(provider.read);
+const read = provider.read;
 
 describe('Providers → Async', () => {
 	describe('.read', () => {
 		it('should return entries', async () => {
 			const dirent = new Dirent('file.txt', DirentType.File);
 
-			const readdir = sinon.stub().yields(null, [dirent]);
+			const readdir = sinon.stub().resolves([dirent]);
 
 			const settings = new Settings({
 				fs: { readdir },
@@ -39,8 +38,8 @@ describe('Providers → Async', () => {
 			const dirent = new Dirent('file.txt', DirentType.File);
 			const stats = new Stats();
 
-			const readdir = sinon.stub().yields(null, [dirent]);
-			const lstat = sinon.stub().yields(null, stats);
+			const readdir = sinon.stub().resolves([dirent]);
+			const lstat = sinon.stub().resolves(stats);
 
 			const settings = new Settings({
 				fs: { readdir, lstat },
@@ -63,9 +62,9 @@ describe('Providers → Async', () => {
 			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
-			const readdir = sinon.stub().yields(null, [dirent]);
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
-			const stat = sinon.stub().yields(null, stats);
+			const readdir = sinon.stub().resolves([dirent]);
+			const lstat = sinon.stub().resolves(new Stats({ mode: StatsMode.Link }));
+			const stat = sinon.stub().resolves(stats);
 
 			const settings = new Settings({
 				fs: { readdir, lstat, stat },
@@ -89,8 +88,8 @@ describe('Providers → Async', () => {
 			const dirent = new Dirent('file.txt', DirentType.Link);
 			const stats = new Stats();
 
-			const readdir = sinon.stub().yields(null, [dirent]);
-			const stat = sinon.stub().yields(null, stats);
+			const readdir = sinon.stub().resolves([dirent]);
+			const stat = sinon.stub().resolves(stats);
 
 			const settings = new Settings({
 				fs: { readdir, stat },
@@ -111,7 +110,7 @@ describe('Providers → Async', () => {
 		it('should do nothing with symbolic links when the "followSymbolicLinks" option is disabled', async () => {
 			const dirent = new Dirent('file.txt', DirentType.Link);
 
-			const readdir = sinon.stub().yields(null, [dirent]);
+			const readdir = sinon.stub().resolves([dirent]);
 
 			const settings = new Settings({
 				fs: { readdir },
@@ -131,8 +130,8 @@ describe('Providers → Async', () => {
 		it('should return lstat for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is disabled', async () => {
 			const dirent = new Dirent('file.txt', DirentType.Link);
 
-			const readdir = sinon.stub().yields(null, [dirent]);
-			const stat = sinon.stub().yields(new Error('error'));
+			const readdir = sinon.stub().resolves([dirent]);
+			const stat = sinon.stub().rejects(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,
@@ -154,8 +153,8 @@ describe('Providers → Async', () => {
 		it('should throw an error for broken symbolic link when the "throwErrorOnBrokenSymbolicLink" option is enabled', async () => {
 			const dirent = new Dirent('file.txt', DirentType.Link);
 
-			const readdir = sinon.stub().yields(null, [dirent]);
-			const stat = sinon.stub().yields(new Error('error'));
+			const readdir = sinon.stub().resolves([dirent]);
+			const stat = sinon.stub().rejects(new Error('error'));
 
 			const settings = new Settings({
 				followSymbolicLinks: true,

--- a/packages/fs/fs.scandir/src/providers/async.ts
+++ b/packages/fs/fs.scandir/src/providers/async.ts
@@ -1,113 +1,59 @@
 import * as fsStat from '@nodelib/fs.stat';
-import * as rpl from 'run-parallel';
 
 import * as utils from '../utils';
 import * as common from './common';
 
 import type { Settings } from '../settings';
-import type { AsyncCallback, Entry, ErrnoException } from '../types';
+import type { Entry } from '../types';
 
-type RplTaskEntry = rpl.Task<Entry>;
-type StatsAction = (callback: fsStat.AsyncCallback) => void;
+export async function read(directory: string, settings: Settings): Promise<Entry[]> {
+	const dirents = await settings.fs.readdir(directory, { withFileTypes: true });
+	const entries: Entry[] = dirents.map((dirent) => ({
+		dirent,
+		name: dirent.name,
+		path: common.joinPathSegments(directory, dirent.name, settings.pathSegmentSeparator),
+	}));
 
-type FailureCallback = (error: ErrnoException | null) => void;
+	if (!settings.stats && !settings.followSymbolicLinks) {
+		return entries;
+	}
 
-export function read(directory: string, settings: Settings, callback: AsyncCallback): void {
-	settings.fs.readdir(directory, { withFileTypes: true }, (readdirError, dirents) => {
-		if (readdirError !== null) {
-			callFailureCallback(callback, readdirError);
-			return;
-		}
-
-		const entries = dirents.map((dirent) => ({
-			dirent,
-			name: dirent.name,
-			path: common.joinPathSegments(directory, dirent.name, settings.pathSegmentSeparator),
-		}));
-
-		if (!settings.stats && !settings.followSymbolicLinks) {
-			callSuccessCallback(callback, entries);
-			return;
-		}
-
-		const tasks = makeRplTasks(entries, settings);
-
-		rpl(tasks, (rplError: Error | null) => {
-			if (rplError !== null) {
-				callFailureCallback(callback, rplError);
-				return;
-			}
-
-			callSuccessCallback(callback, entries);
-		});
-	});
-}
-
-function makeRplTasks(entries: Entry[], settings: Settings): RplTaskEntry[] {
-	const tasks: RplTaskEntry[] = [];
-
+	const tasks = [];
 	for (const entry of entries) {
-		const task = makeRplTask(entry, settings);
+		const action = getStatsAction(entry, settings);
 
-		if (task !== undefined) {
-			tasks.push(task);
+		if (action !== undefined) {
+			tasks.push(action.then((stats) => {
+				if (settings.stats) {
+					entry.stats = stats;
+				}
+
+				if (settings.followSymbolicLinks) {
+					entry.dirent = utils.fs.createDirentFromStats(entry.name, stats);
+				}
+
+				return entry;
+			}, (error) => {
+				if (settings.throwErrorOnBrokenSymbolicLink) {
+					throw error;
+				}
+
+				return entry;
+			}));
 		}
 	}
 
-	return tasks;
+	return Promise.all(tasks);
 }
 
-/**
- * The task mutates the incoming entry object depending on the settings.
- * Returns the task, or undefined if the task is empty.
- */
-function makeRplTask(entry: Entry, settings: Settings): RplTaskEntry | undefined {
-	const action = getStatsAction(entry, settings);
-
-	if (action === undefined) {
-		return undefined;
-	}
-
-	return (done) => {
-		action((error, stats) => {
-			if (error !== null) {
-				done(settings.throwErrorOnBrokenSymbolicLink ? error : null);
-				return;
-			}
-
-			if (settings.stats) {
-				entry.stats = stats;
-			}
-
-			if (settings.followSymbolicLinks) {
-				entry.dirent = utils.fs.createDirentFromStats(entry.name, stats);
-			}
-
-			done(null, entry);
-		});
-	};
-}
-
-function getStatsAction(entry: Entry, settings: Settings): StatsAction | undefined {
+function getStatsAction(entry: Entry, settings: Settings): Promise<fsStat.Stats> | undefined {
 	if (settings.stats) {
-		return (callback) => {
-			fsStat.stat(entry.path, settings.fsStatSettings, callback);
-		};
+		return fsStat.stat(entry.path, settings.fsStatSettings);
 	}
 
 	if (settings.followSymbolicLinks && entry.dirent.isSymbolicLink()) {
-		return (callback) => {
-			settings.fs.stat(entry.path, callback);
-		};
+		return settings.fs.stat(entry.path);
 	}
 
 	return undefined;
-}
-
-function callFailureCallback(callback: AsyncCallback, error: ErrnoException | null): void {
-	(callback as FailureCallback)(error);
-}
-
-function callSuccessCallback(callback: AsyncCallback, result: Entry[]): void {
-	callback(null, result);
 }

--- a/packages/fs/fs.scandir/src/scandir.spec.ts
+++ b/packages/fs/fs.scandir/src/scandir.spec.ts
@@ -19,38 +19,30 @@ describe('Scandir', () => {
 	});
 
 	describe('.scandir', () => {
-		it('should work without options or settings', (done) => {
-			scandir('fixtures', (error, entries) => {
-				assert.strictEqual(error, null);
-				assert.ok(entries[0]?.name);
-				assert.ok(entries[0]?.path);
-				assert.ok(entries[0]?.dirent);
-				done();
-			});
+		it('should work without options or settings', async () => {
+			const entries = await scandir('fixtures');
+			assert.ok(entries[0]?.name);
+			assert.ok(entries[0]?.path);
+			assert.ok(entries[0]?.dirent);
 		});
 
-		it('should work with options', (done) => {
-			scandir('fixtures', { stats: true }, (error, entries) => {
-				assert.strictEqual(error, null);
-				assert.ok(entries[0]?.name);
-				assert.ok(entries[0]?.path);
-				assert.ok(entries[0]?.dirent);
-				assert.ok(entries[0]?.stats);
-				done();
-			});
+		it('should work with options', async () => {
+			const entries = await scandir('fixtures', { stats: true });
+			assert.ok(entries[0]?.name);
+			assert.ok(entries[0]?.path);
+			assert.ok(entries[0]?.dirent);
+			assert.ok(entries[0]?.stats);
 		});
 
-		it('should work with settings', (done) => {
+		it('should work with settings', async () => {
 			const settings = new Settings({ stats: true });
 
-			scandir('fixtures', settings, (error, entries) => {
-				assert.strictEqual(error, null);
-				assert.ok(entries[0]?.name);
-				assert.ok(entries[0]?.path);
-				assert.ok(entries[0]?.dirent);
-				assert.ok(entries[0]?.stats);
-				done();
-			});
+			const entries = await scandir('fixtures', settings);
+
+			assert.ok(entries[0]?.name);
+			assert.ok(entries[0]?.path);
+			assert.ok(entries[0]?.dirent);
+			assert.ok(entries[0]?.stats);
 		});
 	});
 

--- a/packages/fs/fs.scandir/src/scandir.ts
+++ b/packages/fs/fs.scandir/src/scandir.ts
@@ -3,21 +3,10 @@ import * as async from './providers/async';
 import * as sync from './providers/sync';
 
 import type { Options } from './settings';
-import type { AsyncCallback, Entry } from './types';
+import type { Entry } from './types';
 
-export function scandir(path: string, callback: AsyncCallback): void;
-export function scandir(path: string, optionsOrSettings: Options | Settings, callback: AsyncCallback): void;
-export function scandir(path: string, optionsOrSettingsOrCallback: AsyncCallback | Options | Settings, callback?: AsyncCallback): void {
-	if (typeof optionsOrSettingsOrCallback === 'function') {
-		async.read(path, getSettings(), optionsOrSettingsOrCallback);
-		return;
-	}
-
-	async.read(path, getSettings(optionsOrSettingsOrCallback), callback as AsyncCallback);
-}
-
-export declare namespace scandir {
-	function __promisify__(path: string, optionsOrSettings?: Options | Settings): Promise<Entry[]>;
+export function scandir(path: string, optionsOrSettings?: Options | Settings): Promise<Entry[]> {
+	return async.read(path, getSettings(optionsOrSettings));
 }
 
 export function scandirSync(path: string, optionsOrSettings?: Options | Settings): Entry[] {

--- a/packages/fs/fs.scandir/src/types/index.ts
+++ b/packages/fs/fs.scandir/src/types/index.ts
@@ -10,4 +10,3 @@ export interface Entry {
 export type Dirent = fs.Dirent;
 export type Stats = fs.Stats;
 export type ErrnoException = NodeJS.ErrnoException;
-export type AsyncCallback = (error: ErrnoException | null, entries: Entry[]) => void;

--- a/packages/fs/fs.stat/src/adapters/fs.ts
+++ b/packages/fs/fs.stat/src/adapters/fs.ts
@@ -1,8 +1,6 @@
 import * as fs from 'node:fs';
 
-import type { ErrnoException } from '../types';
-
-export type StatAsynchronousMethod = (path: string, callback: (error: ErrnoException | null, stats: fs.Stats) => void) => void;
+export type StatAsynchronousMethod = (path: string) => Promise<fs.Stats>;
 export type StatSynchronousMethod = (path: string) => fs.Stats;
 
 export interface FileSystemAdapter {
@@ -13,8 +11,8 @@ export interface FileSystemAdapter {
 }
 
 export const FILE_SYSTEM_ADAPTER: FileSystemAdapter = {
-	lstat: fs.lstat,
-	stat: fs.stat,
+	lstat: fs.promises.lstat,
+	stat: fs.promises.stat,
 	lstatSync: fs.lstatSync,
 	statSync: fs.statSync,
 };

--- a/packages/fs/fs.stat/src/index.ts
+++ b/packages/fs/fs.stat/src/index.ts
@@ -3,4 +3,4 @@ export { Settings } from './settings';
 
 export type { FileSystemAdapter, StatSynchronousMethod, StatAsynchronousMethod } from './adapters/fs';
 export type { Options } from './settings';
-export type { Stats, AsyncCallback } from './types';
+export type { Stats } from './types';

--- a/packages/fs/fs.stat/src/providers/async.spec.ts
+++ b/packages/fs/fs.stat/src/providers/async.spec.ts
@@ -8,93 +8,80 @@ import * as provider from './async';
 
 describe('Providers → Async', () => {
 	describe('.read', () => {
-		it('should return lstat for non-symlink entry', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats());
+		it('should return lstat for non-symlink entry', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats());
 
 			const settings = new Settings({
 				fs: { lstat },
 			});
 
-			provider.read('filepath', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.ino, 0);
-				done();
-			});
+			const stats = await provider.read('filepath', settings);
+			assert.strictEqual(stats.ino, 0);
 		});
 
-		it('should return lstat for symlink entry when the "followSymbolicLink" option is disabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
+		it('should return lstat for symlink entry when the "followSymbolicLink" option is disabled', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ mode: StatsMode.Link }));
 
 			const settings = new Settings({
 				followSymbolicLink: false,
 				fs: { lstat },
 			});
 
-			provider.read('filepath', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.ino, 0);
-				done();
-			});
+			const stats = await provider.read('filepath', settings);
+			assert.strictEqual(stats.ino, 0);
 		});
 
-		it('should return stat for symlink entry', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
-			const stat = sinon.stub().yields(null, new Stats({ ino: 1 }));
+		it('should return stat for symlink entry', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ mode: StatsMode.Link }));
+			const stat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ ino: 1 }));
 
 			const settings = new Settings({
 				fs: { lstat, stat },
 			});
 
-			provider.read('filepath', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.ino, 1);
-				done();
-			});
+			const stats = await provider.read('filepath', settings);
+			assert.strictEqual(stats.ino, 1);
 		});
 
-		it('should return marked stat for symlink entry when the "markSymbolicLink" option is enabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
-			const stat = sinon.stub().yields(null, new Stats({ ino: 1 }));
+		it('should return marked stat for symlink entry when the "markSymbolicLink" option is enabled', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ mode: StatsMode.Link }));
+			const stat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ ino: 1 }));
 
 			const settings = new Settings({
 				fs: { lstat, stat },
 				markSymbolicLink: true,
 			});
 
-			provider.read('filepath', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.isSymbolicLink(), true);
-				done();
-			});
+			const stats = await provider.read('filepath', settings);
+			assert.strictEqual(stats.isSymbolicLink(), true);
 		});
 
-		it('should return lstat for broken symlink entry when the "throwErrorOnBrokenSymbolicLink" option is disabled', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
-			const stat = sinon.stub().yields(new Error('error_message'));
+		it('should return lstat for broken symlink entry when the "throwErrorOnBrokenSymbolicLink" option is disabled', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ mode: StatsMode.Link }));
+			const stat = sinon.stub<[string], Promise<Stats>>().rejects(new Error('error_message'));
 
 			const settings = new Settings({
 				fs: { lstat, stat },
 				throwErrorOnBrokenSymbolicLink: false,
 			});
 
-			provider.read('filepath', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.ino, 0);
-				done();
-			});
+			const stats = await provider.read('filepath', settings);
+			assert.strictEqual(stats.ino, 0);
 		});
 
-		it('should throw an error when symlink entry is broken', (done) => {
-			const lstat = sinon.stub().yields(null, new Stats({ mode: StatsMode.Link }));
-			const stat = sinon.stub().yields(new Error('broken'));
+		it('should throw an error when symlink entry is broken', async () => {
+			const lstat = sinon.stub<[string], Promise<Stats>>().resolves(new Stats({ mode: StatsMode.Link }));
+			const stat = sinon.stub<[string], Promise<Stats>>().rejects(new Error('broken'));
 
 			const settings = new Settings({
 				fs: { lstat, stat },
 			});
 
-			provider.read('filepath', settings, (error) => {
-				assert.strictEqual(error?.message, 'broken');
-				done();
+			await assert.rejects(async () => {
+				await provider.read('filepath', settings);
+			}, (error) => {
+				assert.strictEqual((error as Error | null)?.message, 'broken');
+				return true;
 			});
 		});
 	});

--- a/packages/fs/fs.stat/src/stat.spec.ts
+++ b/packages/fs/fs.stat/src/stat.spec.ts
@@ -20,30 +20,21 @@ describe('Stat', () => {
 	});
 
 	describe('.stat', () => {
-		it('should work without options or settings', (done) => {
-			stat('fixtures/b', (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.ok(stats);
-				done();
-			});
+		it('should work without options or settings', async () => {
+			const stats = await stat('fixtures/b');
+			assert.ok(stats);
 		});
 
-		it('should work with options', (done) => {
-			stat('fixtures/b', { markSymbolicLink: true }, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.isSymbolicLink(), true);
-				done();
-			});
+		it('should work with options', async () => {
+			const stats = await stat('fixtures/b', { markSymbolicLink: true });
+			assert.strictEqual(stats.isSymbolicLink(), true);
 		});
 
-		it('should work with settings', (done) => {
+		it('should work with settings', async () => {
 			const settings = new Settings({ markSymbolicLink: true });
 
-			stat('fixtures/b', settings, (error, stats) => {
-				assert.strictEqual(error, null);
-				assert.strictEqual(stats.isSymbolicLink(), true);
-				done();
-			});
+			const stats = await stat('fixtures/b', settings);
+			assert.strictEqual(stats.isSymbolicLink(), true);
 		});
 	});
 

--- a/packages/fs/fs.stat/src/stat.ts
+++ b/packages/fs/fs.stat/src/stat.ts
@@ -3,21 +3,10 @@ import * as sync from './providers/sync';
 import { Settings } from './settings';
 
 import type { Options } from './settings';
-import type { AsyncCallback, Stats } from './types';
+import type { Stats } from './types';
 
-export function stat(path: string, callback: AsyncCallback): void;
-export function stat(path: string, optionsOrSettings: Options | Settings, callback: AsyncCallback): void;
-export function stat(path: string, optionsOrSettingsOrCallback: AsyncCallback | Options | Settings, callback?: AsyncCallback): void {
-	if (typeof optionsOrSettingsOrCallback === 'function') {
-		async.read(path, getSettings(), optionsOrSettingsOrCallback);
-		return;
-	}
-
-	async.read(path, getSettings(optionsOrSettingsOrCallback), callback as AsyncCallback);
-}
-
-export declare namespace stat {
-	function __promisify__(path: string, optionsOrSettings?: Options | Settings): Promise<Stats>;
+export function stat(path: string, optionsOrSettings?: Options | Settings): Promise<Stats> {
+	return async.read(path, getSettings(optionsOrSettings));
 }
 
 export function statSync(path: string, optionsOrSettings?: Options | Settings): Stats {

--- a/packages/fs/fs.stat/src/types/index.ts
+++ b/packages/fs/fs.stat/src/types/index.ts
@@ -1,5 +1,3 @@
 import type * as fs from 'node:fs';
 
 export type Stats = fs.Stats;
-export type ErrnoException = NodeJS.ErrnoException;
-export type AsyncCallback = (error: ErrnoException | null, stats: Stats) => void;


### PR DESCRIPTION
### What is the purpose of this pull request?
Progress towards #106; `fs.stat` and `fs.scandir` now use a promise-based API. This makes the code a lot tidier, provides a nicer API for users, and lets us get rid of the `run-parallel` dependency.

### What changes did you make? (Give an overview)
"Promisified" the async versions of the `fs.stat` and `fs.scandir` functions. This will require a major version bump.

I'm running into some issues with `npm link` and resolving the new versions of dependencies when trying to update `fs.walk` as well, so I'm submitting these changes first.
