### PR TITLE
fix(fs.scandir): Fix TypeError in DirentFromStats. Closes #110

### DIFF
--- a/packages/fs/fs.scandir/src/utils/fs.ts
+++ b/packages/fs/fs.scandir/src/utils/fs.ts
@@ -27,11 +27,13 @@ export class DirentFromStats extends fs.Dirent {
 for (const key of Reflect.ownKeys(fs.Dirent.prototype)) {
 	const name = key as DirentStatsKeysIntersection | 'constructor';
 
-	if (name === 'constructor') {
+	const descriptor = Object.getOwnPropertyDescriptor(fs.Dirent.prototype, name);
+
+	if (descriptor && (!(descriptor.writable ?? false) && !descriptor.set)) {
 		continue;
 	}
 
-	DirentFromStats.prototype[name] = function () {
-		return this[kStats][name]();
+	DirentFromStats.prototype[name] = function <T>(): T {
+		return this[kStats][name]() as T;
 	};
 }


### PR DESCRIPTION
Fixed the TypeError occurring when attempting to set a property with only a getter in the DirentFromStats class. The function now returns the correct values, avoiding overwriting read-only properties.
