### PR TITLE
benchmark5

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup environment
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
       - name: Install root dependencies
         run: npm install
       - name: Link package dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [16.14.0, 16, 18, 20]
+        node_version: [16.14.0, 16, 18, 20, 22, 23]
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
   "devDependencies": {
     "@nodelib-internal/tools.size-limit": "file:tools/size-limit",
     "@times-components/depend": "2.3.0",
-    "@types/mocha": "^10.0.1",
-    "@types/node": "^18.19.6",
-    "@types/sinon": "^10.0.14",
-    "bencho": "^0.1.1",
-    "eslint": "^8.45.0",
-    "eslint-config-mrmlnc": "^4.0.1",
-    "execa": "^7.1.1",
-    "hereby": "^1.8.1",
-    "lerna": "^5.6.2",
-    "mocha": "^10.2.0",
-    "rimraf": "^5.0.0",
-    "sinon": "^15.0.3",
-    "typescript": "^5.1.6"
+    "@types/mocha": "10.0.9",
+    "@types/node": "18.19.64",
+    "@types/sinon": "17.0.3",
+    "bencho": "0.1.1",
+    "eslint": "8.57.1",
+    "eslint-config-mrmlnc": "4.1.1",
+    "execa": "9.5.1",
+    "hereby": "1.10.0",
+    "lerna": "5.6.2",
+    "mocha": "10.8.2",
+    "rimraf": "6.0.1",
+    "sinon": "19.0.2",
+    "typescript": "5.6.3"
   }
 }

--- a/packages/fs/fs.macchiato/src/stats.spec.ts
+++ b/packages/fs/fs.macchiato/src/stats.spec.ts
@@ -127,10 +127,10 @@ describe('Stats', () => {
 		assert.strictEqual(stats.mtimeMs, date.getTime());
 		assert.strictEqual(stats.ctimeMs, date.getTime());
 		assert.strictEqual(stats.birthtimeMs, date.getTime());
-		assert.deepStrictEqual(stats.atime, date);
-		assert.deepStrictEqual(stats.mtime, date);
-		assert.deepStrictEqual(stats.ctime, date);
-		assert.deepStrictEqual(stats.birthtime, date);
+		assert.strictEqual(stats.atime.getTime(), date.getTime());
+		assert.strictEqual(stats.mtime.getTime(), date.getTime());
+		assert.strictEqual(stats.ctime.getTime(), date.getTime());
+		assert.strictEqual(stats.birthtime.getTime(), date.getTime());
 		assert.ok(!stats.isFile());
 		assert.ok(stats.isDirectory());
 		assert.ok(!stats.isSymbolicLink());

--- a/packages/fs/fs.scandir/src/utils/fs.ts
+++ b/packages/fs/fs.scandir/src/utils/fs.ts
@@ -25,13 +25,14 @@ export class DirentFromStats extends fs.Dirent {
 }
 
 for (const key of Reflect.ownKeys(fs.Dirent.prototype)) {
-	const name = key as DirentStatsKeysIntersection | 'constructor';
+	const name = key as DirentStatsKeysIntersection;
+	const descriptor = Object.getOwnPropertyDescriptor(fs.Dirent.prototype, name);
 
-	if (name === 'constructor') {
+	if (descriptor?.writable === false || descriptor?.set === undefined) {
 		continue;
 	}
 
-	DirentFromStats.prototype[name] = function () {
-		return this[kStats][name]();
+	DirentFromStats.prototype[name] = function <T>(): T {
+		return this[kStats][name]() as T;
 	};
 }

--- a/packages/fs/fs.walk/herebyfile.mjs
+++ b/packages/fs/fs.walk/herebyfile.mjs
@@ -29,7 +29,7 @@ function getRepositoryRoot() {
 async function benchTask(suite, spec) {
 	const root = getRepositoryRoot();
 	const label = spec.label;
-	const implementations = spec.implementations;
+	const implementations = spec.implementations.filter((it) => (spec.exclude ?? []).includes(it) === false);
 	const options = spec.options ?? {};
 
 	await execa('bencho', [
@@ -84,6 +84,7 @@ function makeBenchSuiteTask(label, suite, implementations = []) {
 			label,
 			implementations,
 			options: { stats: true },
+			exclude: ['native'],
 		}),
 	});
 
@@ -94,6 +95,7 @@ function makeBenchSuiteTask(label, suite, implementations = []) {
 			label,
 			implementations,
 			options: { followSymbolicLinks: true, throwErrorOnBrokenSymbolicLink: false },
+			exclude: ['native'],
 		}),
 	});
 

--- a/packages/fs/fs.walk/herebyfile.mjs
+++ b/packages/fs/fs.walk/herebyfile.mjs
@@ -33,7 +33,7 @@ async function benchTask(suite, spec) {
 	const options = spec.options ?? {};
 
 	await execa('bencho', [
-		`'node ${suite} {impl} ${root}'`,
+		`"node ${suite} {impl} ${root}"`,
 		`-n "${label} {impl} <root>"`,
 		`-w ${WARMUP_COUNT}`,
 		`-r ${RUNS_COUNT}`,
@@ -109,7 +109,7 @@ export const {
 	asyncTask,
 	streamTask,
 } = {
-	syncTask: makeBenchSuiteTask('sync', REGRESSION_SYNC_SUITE, ['current', 'previous']),
-	asyncTask: makeBenchSuiteTask('async', REGRESSION_ASYNC_SUITE, ['current', 'previous']),
+	syncTask: makeBenchSuiteTask('sync', REGRESSION_SYNC_SUITE, ['current', 'previous', 'native']),
+	asyncTask: makeBenchSuiteTask('async', REGRESSION_ASYNC_SUITE, ['current', 'previous', 'native']),
 	streamTask: makeBenchSuiteTask('stream', REGRESSION_STREAM_SUITE, ['current', 'previous']),
 };


### PR DESCRIPTION
- **build: update dev dependencies**
- **refactor(fs.scandir): fix issue with upcoming Dirent changes**
- **perf: add native node:fs readdir to benchmark**
- **ci: introduce regular builds for node@22 & 23**
- **ci: run benchmark on the latest LTS version**
