### PR TITLE
Replace lerna with npm workspaces and lerna-lite

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -31,7 +31,7 @@ If you find your issue already exists, make relevant comments and add your [reac
 * Install [Node.js](https://nodejs.org/en/).
 * Fork the project and clone the fork repository. ([how to create fork?](https://help.github.com/articles/fork-a-repo/#fork-an-example-repository)).
 * Create a topic branch from the master branch.
-* Run `npm i && npx lerna bootstrap` to install dependencies for all packages.
+* Run `npm install` to install dependencies for all packages.
 
 #### Setup
 
@@ -41,7 +41,6 @@ If you find your issue already exists, make relevant comments and add your [reac
 git clone https://github.com/nodelib/nodelib
 cd nodelib
 npm install
-npx lerna bootstrap
 ```
 
 Then you can either run:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,10 +34,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-      - name: Install root dependencies
+      - name: Install dependencies
         run: npm install
-      - name: Link package dependencies
-        run: npx lerna bootstrap
       - name: Compile sources
         run: npm run compile
       - name: Benchmark

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
-      - name: Install root dependencies
+      - name: Install dependencies
         run: npm install
-      - name: Link package dependencies
-        run: npx lerna bootstrap
       - name: Compile sources
         run: npm run compile
       - name: Run hygiene checks

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 package-lock=false
 access=public
+save-exact=true

--- a/lerna.json
+++ b/lerna.json
@@ -14,9 +14,6 @@
 		"add": {
 			"exact": true
 		},
-		"bootstrap": {
-			"ci": false
-		},
 		"publish": {
 			"allowBranch": "master",
 			"exact": true,

--- a/package.json
+++ b/package.json
@@ -7,12 +7,16 @@
   "engines": {
     "node": ">=16.14.0"
   },
+  "workspaces": [
+    "packages/*/*",
+    "tools/*"
+  ],
   "scripts": {
     "preversion": "npm run lint:size",
     "clean": "lerna run --parallel clean",
     "lint": "lerna run --parallel lint",
     "lint:dependencies": "depend --lerna . --bail --hint --strategy=conservative",
-    "lint:size": "lerna exec tools.size-limit --no-private --parallel",
+    "lint:size": "lerna exec tools-size-limit --no-private --stream",
     "compile": "tsc -b ./packages --verbose",
     "test": "lerna run --parallel test",
     "build": "npm run clean && npm run compile && npm run lint && npm run test",
@@ -20,6 +24,9 @@
     "bench": "lerna run bench --stream"
   },
   "devDependencies": {
+    "@lerna-lite/cli": "3.10.0",
+    "@lerna-lite/exec": "3.10.0",
+    "@lerna-lite/run": "3.10.0",
     "@nodelib-internal/tools.size-limit": "file:tools/size-limit",
     "@times-components/depend": "2.3.0",
     "@types/mocha": "10.0.9",
@@ -30,7 +37,6 @@
     "eslint-config-mrmlnc": "5.0.0",
     "execa": "9.5.1",
     "hereby": "1.10.0",
-    "lerna": "5.6.2",
     "mocha": "10.8.2",
     "rimraf": "6.0.1",
     "sinon": "19.0.2",

--- a/tools/size-limit/package.json
+++ b/tools/size-limit/package.json
@@ -3,7 +3,7 @@
   "name": "@nodelib-internal/tools.size-limit",
   "version": "0.0.0",
   "bin": {
-    "tools.size-limit": "size-limit.mjs"
+    "tools-size-limit": "size-limit.mjs"
   },
   "scripts": {
     "lint": "eslint \"**/*.mjs\" --cache"


### PR DESCRIPTION
### What is the purpose of this pull request?

The `lerna` package is outdated and generates a lot of warnings during installation. In new versions, lerna is shipped without the `bootstrap` command needed to install and link dependencies.

### What changes did you make? (Give an overview)

After some investigation, I think we need to stay with npm to install dependencies. It just works. We have no problems with dependency installation time, so pnpm looks like too complicated a solution for me. It is no longer just a package manager, it is a whole toolchain. On the other side is yarn, which has gotten better over the years, but it still needs to be additionally installed.

Let's revisit this discussion when new versions of the tools become available.
