### PR TITLE
fix(fs.walk+fs.scandir): promises export entry

### DIFF
--- a/packages/fs/fs.scandir/package.json
+++ b/packages/fs/fs.scandir/package.json
@@ -29,7 +29,7 @@
       "default": "./out/index.js"
     },
     "./promises": {
-      "default": "./out/stat-promises.js"
+      "default": "./out/scandir-promises.js"
     }
   },
   "scripts": {

--- a/packages/fs/fs.walk/package.json
+++ b/packages/fs/fs.walk/package.json
@@ -30,7 +30,7 @@
       "default": "./out/index.js"
     },
     "./promises": {
-      "default": "./out/stat-promises.js"
+      "default": "./out/walk-promises.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
### What is the purpose of this pull request?

Enable "@nodelib/fs.walk/promises" and "@nodelib/fs.scandir/promises" imports.

### What changes did you make? (Give an overview)

Correct the export entries to point to the correct filenames.