### PR TITLE
Get rid of __exportStar helper

### DIFF
--- a/packages/fs/fs.scandir/src/providers/async.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/async.spec.ts
@@ -7,7 +7,7 @@ import { Dirent, DirentType, Stats, StatsMode } from '@nodelib/fs.macchiato';
 import { describe, it } from 'mocha';
 
 import { Settings } from '../settings';
-import * as utils from '../utils';
+import * as fsUtils from '../utils/fs';
 import * as provider from './async';
 
 import type { Entry } from '../types';
@@ -77,7 +77,7 @@ describe('Providers → Async', () => {
 			const expected: Entry[] = [{
 				name: 'file.txt',
 				path: path.join('root', 'file.txt'),
-				dirent: utils.fs.createDirentFromStats('file.txt', stats, 'root'),
+				dirent: fsUtils.createDirentFromStats('file.txt', stats, 'root'),
 				stats,
 			}];
 
@@ -101,7 +101,7 @@ describe('Providers → Async', () => {
 			const expected: Entry[] = [{
 				name: 'file.txt',
 				path: path.join('root', 'file.txt'),
-				dirent: utils.fs.createDirentFromStats('file.txt', stats, 'root'),
+				dirent: fsUtils.createDirentFromStats('file.txt', stats, 'root'),
 			}];
 
 			const actual = await read('root', settings);

--- a/packages/fs/fs.scandir/src/providers/async.ts
+++ b/packages/fs/fs.scandir/src/providers/async.ts
@@ -1,7 +1,7 @@
 import * as fsStat from '@nodelib/fs.stat';
 import * as rpl from 'run-parallel';
 
-import * as utils from '../utils';
+import * as fsUtils from '../utils/fs';
 import * as common from './common';
 
 import type { Settings } from '../settings';
@@ -80,7 +80,7 @@ function makeRplTask(directory: string, entry: Entry, settings: Settings): RplTa
 			}
 
 			if (settings.followSymbolicLinks) {
-				entry.dirent = utils.fs.createDirentFromStats(entry.name, stats, directory);
+				entry.dirent = fsUtils.createDirentFromStats(entry.name, stats, directory);
 			}
 
 			done(null, entry);

--- a/packages/fs/fs.scandir/src/providers/sync.spec.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.spec.ts
@@ -6,7 +6,7 @@ import { Dirent, DirentType, Stats, StatsMode } from '@nodelib/fs.macchiato';
 import { describe, it } from 'mocha';
 
 import { Settings } from '../settings';
-import * as utils from '../utils';
+import * as fsUtils from '../utils/fs';
 import * as provider from './sync';
 
 import type { Entry } from '../types';
@@ -74,7 +74,7 @@ describe('Providers → Sync', () => {
 			const expected: Entry[] = [{
 				name: 'file.txt',
 				path: path.join('root', 'file.txt'),
-				dirent: utils.fs.createDirentFromStats('file.txt', stats, 'root'),
+				dirent: fsUtils.createDirentFromStats('file.txt', stats, 'root'),
 				stats,
 			}];
 
@@ -98,7 +98,7 @@ describe('Providers → Sync', () => {
 			const expected: Entry[] = [{
 				name: 'file.txt',
 				path: path.join('root', 'file.txt'),
-				dirent: utils.fs.createDirentFromStats('file.txt', stats, 'root'),
+				dirent: fsUtils.createDirentFromStats('file.txt', stats, 'root'),
 			}];
 
 			const actual = provider.read('root', settings);

--- a/packages/fs/fs.scandir/src/providers/sync.ts
+++ b/packages/fs/fs.scandir/src/providers/sync.ts
@@ -1,6 +1,6 @@
 import * as fsStat from '@nodelib/fs.stat';
 
-import * as utils from '../utils';
+import * as fsUtils from '../utils/fs';
 import * as common from './common';
 
 import type { Settings } from '../settings';
@@ -24,7 +24,7 @@ export function read(directory: string, settings: Settings): Entry[] {
 			try {
 				const stats = entry.stats ?? settings.fs.statSync(entry.path);
 
-				entry.dirent = utils.fs.createDirentFromStats(entry.name, stats, directory);
+				entry.dirent = fsUtils.createDirentFromStats(entry.name, stats, directory);
 			} catch (error: unknown) {
 				if (settings.throwErrorOnBrokenSymbolicLink) {
 					throw (error as ErrnoException);

--- a/packages/fs/fs.scandir/src/utils/index.ts
+++ b/packages/fs/fs.scandir/src/utils/index.ts
@@ -1,1 +1,0 @@
-export * as fs from './fs';

--- a/packages/fs/fs.walk/src/providers/async.spec.ts
+++ b/packages/fs/fs.walk/src/providers/async.spec.ts
@@ -6,7 +6,7 @@ import { describe, it } from 'mocha';
 import * as tests from '../tests';
 import { AsyncProvider } from './async';
 
-import type { IAsyncReader } from '../readers';
+import type { IAsyncReader } from '../readers/async';
 
 class TestProvider extends AsyncProvider {
 	public readonly reader: sinon.SinonStubbedInstance<IAsyncReader>;

--- a/packages/fs/fs.walk/src/providers/async.ts
+++ b/packages/fs/fs.walk/src/providers/async.ts
@@ -1,4 +1,4 @@
-import type { IAsyncReader } from '../readers';
+import type { IAsyncReader } from '../readers/async';
 import type { Entry, ErrnoException } from '../types';
 
 export type AsyncCallback = (error: ErrnoException | null, entries: Entry[]) => void;

--- a/packages/fs/fs.walk/src/providers/index.ts
+++ b/packages/fs/fs.walk/src/providers/index.ts
@@ -1,3 +1,0 @@
-export * from './async';
-export * from './stream';
-export * from './sync';

--- a/packages/fs/fs.walk/src/providers/stream.ts
+++ b/packages/fs/fs.walk/src/providers/stream.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'node:stream';
 
-import type { IAsyncReader } from '../readers';
+import type { IAsyncReader } from '../readers/async';
 
 export class StreamProvider {
 	readonly #reader: IAsyncReader;

--- a/packages/fs/fs.walk/src/providers/sync.spec.ts
+++ b/packages/fs/fs.walk/src/providers/sync.spec.ts
@@ -6,7 +6,7 @@ import * as tests from '../tests';
 import { SyncProvider } from './sync';
 
 import type { SinonStubbedInstance } from 'sinon';
-import type { ISyncReader } from '../readers';
+import type { ISyncReader } from '../readers/sync';
 
 class TestProvider extends SyncProvider {
 	public readonly reader: SinonStubbedInstance<ISyncReader>;

--- a/packages/fs/fs.walk/src/providers/sync.ts
+++ b/packages/fs/fs.walk/src/providers/sync.ts
@@ -1,4 +1,4 @@
-import type { ISyncReader } from '../readers';
+import type { ISyncReader } from '../readers/sync';
 import type { Entry } from '../types';
 
 export class SyncProvider {

--- a/packages/fs/fs.walk/src/readers/index.ts
+++ b/packages/fs/fs.walk/src/readers/index.ts
@@ -1,2 +1,0 @@
-export * from './async';
-export * from './sync';

--- a/packages/fs/fs.walk/src/walk.ts
+++ b/packages/fs/fs.walk/src/walk.ts
@@ -1,12 +1,15 @@
-import { AsyncProvider, StreamProvider, SyncProvider } from './providers';
 import { Settings } from './settings';
-import { AsyncReader, SyncReader } from './readers';
 import { FileSystemAdapter } from './adapters/fs';
+import { AsyncProvider } from './providers/async';
+import { AsyncReader } from './readers/async';
+import { SyncReader } from './readers/sync';
+import { SyncProvider } from './providers/sync';
+import { StreamProvider } from './providers/stream';
 
-import type { Options } from './settings';
-import type { AsyncCallback } from './providers';
-import type { Readable } from 'node:stream';
+import type { AsyncCallback } from './providers/async';
 import type { Entry } from './types';
+import type { Readable } from 'node:stream';
+import type { Options } from './settings';
 
 const fs = new FileSystemAdapter();
 


### PR DESCRIPTION
- **refactor(fs.scandir): get rid of __exportStar helper**
- **refactor(fs.walk): get rid of __exportStar helper**
