### PR TITLE
perf(fs.walk): avoid extra loop ticks for destroyed reader

### DIFF
--- a/packages/fs/fs.walk/src/readers/async.ts
+++ b/packages/fs/fs.walk/src/readers/async.ts
@@ -129,6 +129,14 @@ export class AsyncReader extends AsyncReaderEmitter implements IAsyncReader {
 			 */
 			try {
 				for (const entry of entries) {
+					/**
+					 * When the reader is destroyed, there is no need to process entries.
+					 * Break the loop to avoid extra CPU ticks.
+					 */
+					if (this.#isDestroyed || this.#isFatalError) {
+						break;
+					}
+
 					this.#handleEntry(entry, item.base);
 				}
 			} catch (error) {
@@ -152,10 +160,6 @@ export class AsyncReader extends AsyncReaderEmitter implements IAsyncReader {
 	}
 
 	#handleEntry(entry: Entry, base: string | undefined): void {
-		if (this.#isDestroyed || this.#isFatalError) {
-			return;
-		}
-
 		const fullpath = entry.path;
 
 		if (base !== undefined) {


### PR DESCRIPTION
### What is the purpose of this pull request?
…

### What changes did you make? (Give an overview)

After destroying the reader before this changes, the entries processing loop continued to run, rather than being interrupted. There were ~10 times more ticks before the changes for this snippet:

```js
import * as fs from './packages/fs/fs.walk/out/index.js';

const ac = new AbortController();

setTimeout(() => {
	ac.abort();
}, 10);

fs.walk('.', { signal: ac.signal }, (error, entries) => {
	if (error !== null) {
		console.dir(error, { colors: true, compact: false, depth: 2 });
		return;
	}

	console.dir(entries.length, { colors: true, compact: false, depth: 2 });
});
```
